### PR TITLE
Potential fix for code scanning alert no. 1: Log entries created from user input

### DIFF
--- a/Samples/Mediarq.Samples.WebApi/Features/Orders/ConfirmOrder.cs
+++ b/Samples/Mediarq.Samples.WebApi/Features/Orders/ConfirmOrder.cs
@@ -27,7 +27,10 @@ public sealed class ConfirmOrderHandler(AppDbContext db, ILogger<ConfirmOrderHan
             return Result.Failure(ResultError.NotFound("Order.NotFound", $"Order {request.OrderId} was not found."));
 
         // Only logged on the first call for a given key; replays skip the handler entirely.
-        logger.LogInformation("Confirming order {OrderId} (key {Key})", request.OrderId, request.IdempotencyKey);
+        var sanitizedKey = request.IdempotencyKey
+            .Replace("\r", string.Empty)
+            .Replace("\n", string.Empty);
+        logger.LogInformation("Confirming order {OrderId} (key {Key})", request.OrderId, sanitizedKey);
 
         order.Status = OrderStatus.Confirmed;
         await db.SaveChangesAsync(cancellationToken);


### PR DESCRIPTION
Potential fix for [https://github.com/rouffou/mediarq/security/code-scanning/1](https://github.com/rouffou/mediarq/security/code-scanning/1)

To fix this without changing functionality, sanitize the user-provided idempotency key before logging it by removing CR/LF (and optionally other line-separator characters). The safest minimal change is in `ConfirmOrderHandler` right before the log statement, so only log output is normalized while request processing/idempotency behavior remains unchanged.

Best concrete fix:
- File: `Samples/Mediarq.Samples.WebApi/Features/Orders/ConfirmOrder.cs`
- In `Handle(...)`, create a local `sanitizedKey` from `request.IdempotencyKey` that strips `\r` and `\n`.
- Log `sanitizedKey` instead of raw `request.IdempotencyKey`.

No additional imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
