### PR TITLE
test(reliability): raise coverage for idempotency, outbox and caching (v1.1)

### DIFF
--- a/Tests/Mediarq.Caching.Tests/CachingBehaviorTests.cs
+++ b/Tests/Mediarq.Caching.Tests/CachingBehaviorTests.cs
@@ -16,6 +16,13 @@ public class CachingBehaviorTests
         public string CacheKey => Key;
     }
 
+    public record TimedQuery(string Key, TimeSpan? Duration) : IQuery<Result<string>>, ICacheableRequest
+    {
+        public string CacheKey => Key;
+
+        public TimeSpan? CacheDuration => Duration;
+    }
+
     public record PlainQuery : IQuery<Result<string>>;
 
     private static CachingBehavior<TRequest, TResponse> Behavior<TRequest, TResponse>(IMemoryCache cache)
@@ -57,6 +64,68 @@ public class CachingBehaviorTests
     }
 
     [Fact]
+    public async Task Runs_Handler_Again_For_A_Different_Key()
+    {
+        using var cache = new MemoryCache(new MemoryCacheOptions());
+        var behavior = Behavior<CachedQuery, Result<string>>(cache);
+
+        var calls = 0;
+        Task<Result<string>> Handle()
+        {
+            calls++;
+            return Task.FromResult(Result.Success($"value-{calls}"));
+        }
+
+        await behavior.Handle(new RequestContext<CachedQuery, Result<string>>(new CachedQuery("a"), "user"), Handle);
+        await behavior.Handle(new RequestContext<CachedQuery, Result<string>>(new CachedQuery("b"), "user"), Handle);
+
+        calls.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task Honors_A_Custom_CacheDuration_And_Still_Serves_From_Cache()
+    {
+        using var cache = new MemoryCache(new MemoryCacheOptions());
+        var behavior = Behavior<TimedQuery, Result<string>>(cache);
+
+        var calls = 0;
+        Task<Result<string>> Handle()
+        {
+            calls++;
+            return Task.FromResult(Result.Success($"value-{calls}"));
+        }
+
+        var request = new TimedQuery("k", TimeSpan.FromMinutes(5));
+        await behavior.Handle(new RequestContext<TimedQuery, Result<string>>(request, "user"), Handle);
+        var second = await behavior.Handle(new RequestContext<TimedQuery, Result<string>>(request, "user"), Handle);
+
+        calls.Should().Be(1);
+        second.Value.Should().Be("value-1");
+    }
+
+    [Fact]
+    public void Constructor_Rejects_A_Null_Cache()
+    {
+        var act = () => new CachingBehavior<CachedQuery, Result<string>>(null!);
+
+        act.Should().Throw<ArgumentNullException>().WithParameterName("cache");
+    }
+
+    [Fact]
+    public async Task Handle_Rejects_Null_Arguments()
+    {
+        using var cache = new MemoryCache(new MemoryCacheOptions());
+        var behavior = Behavior<CachedQuery, Result<string>>(cache);
+        var context = new RequestContext<CachedQuery, Result<string>>(new CachedQuery("k"), "user");
+
+        var nullContext = async () => await behavior.Handle(null!, () => Task.FromResult(Result.Success("x")));
+        var nullHandle = async () => await behavior.Handle(context, null!);
+
+        await nullContext.Should().ThrowAsync<ArgumentNullException>().WithParameterName("context");
+        await nullHandle.Should().ThrowAsync<ArgumentNullException>().WithParameterName("handle");
+    }
+
+    [Fact]
     public void AddMediarqCaching_Registers_Behavior_And_MemoryCache()
     {
         var services = new ServiceCollection();
@@ -66,5 +135,13 @@ public class CachingBehaviorTests
         services.Should().Contain(d => d.ServiceType == typeof(IMemoryCache));
         services.Should().Contain(d => d.ServiceType == typeof(IPipelineBehavior<,>)
             && d.ImplementationType == typeof(CachingBehavior<,>));
+    }
+
+    [Fact]
+    public void AddMediarqCaching_Rejects_A_Null_ServiceCollection()
+    {
+        var act = () => ((IServiceCollection)null!).AddMediarqCaching();
+
+        act.Should().Throw<ArgumentNullException>().WithParameterName("services");
     }
 }

--- a/Tests/Mediarq.Caching.Tests/DistributedCachingBehaviorTests.cs
+++ b/Tests/Mediarq.Caching.Tests/DistributedCachingBehaviorTests.cs
@@ -18,7 +18,21 @@ public class DistributedCachingBehaviorTests
         public string CacheKey => Key;
     }
 
+    public record TimedQuery(string Key, TimeSpan? Duration) : IQuery<Result<string>>, ICacheableRequest
+    {
+        public string CacheKey => Key;
+
+        public TimeSpan? CacheDuration => Duration;
+    }
+
+    public record NullableQuery(string Key) : IQuery<string?>, ICacheableRequest
+    {
+        public string CacheKey => Key;
+    }
+
     public record PlainQuery : IQuery<Result<string>>;
+
+    public sealed record OrderDto(int Id, string Customer, decimal Total);
 
     private static IDistributedCache NewCache()
         => new MemoryDistributedCache(Options.Create(new MemoryDistributedCacheOptions()));
@@ -73,11 +87,138 @@ public class DistributedCachingBehaviorTests
     }
 
     [Fact]
+    public async Task Runs_Handler_Again_For_A_Different_Key()
+    {
+        var cache = NewCache();
+        var behavior = Behavior(cache);
+
+        var calls = 0;
+        Task<Result<string>> Handle()
+        {
+            calls++;
+            return Task.FromResult(Result.Success($"value-{calls}"));
+        }
+
+        await behavior.Handle(new RequestContext<CachedQuery, Result<string>>(new CachedQuery("a"), "user"), Handle);
+        await behavior.Handle(new RequestContext<CachedQuery, Result<string>>(new CachedQuery("b"), "user"), Handle);
+
+        calls.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task Does_Not_Cache_A_Null_Response_So_The_Handler_Runs_Again()
+    {
+        var cache = NewCache();
+        var behavior = new DistributedCachingBehavior<NullableQuery, string?>(cache, new JsonMediarqCacheSerializer());
+
+        var calls = 0;
+        Task<string?> Handle()
+        {
+            calls++;
+            return Task.FromResult<string?>(calls == 1 ? null : $"value-{calls}");
+        }
+
+        var first = await behavior.Handle(new RequestContext<NullableQuery, string?>(new NullableQuery("k"), "user"), Handle);
+        var second = await behavior.Handle(new RequestContext<NullableQuery, string?>(new NullableQuery("k"), "user"), Handle);
+
+        first.Should().BeNull();
+        second.Should().Be("value-2");
+        calls.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task Honors_A_Custom_CacheDuration_And_Still_Serves_From_Cache()
+    {
+        var cache = NewCache();
+        var behavior = new DistributedCachingBehavior<TimedQuery, Result<string>>(cache, new JsonMediarqCacheSerializer());
+
+        var calls = 0;
+        Task<Result<string>> Handle()
+        {
+            calls++;
+            return Task.FromResult(Result.Success($"value-{calls}"));
+        }
+
+        var request = new TimedQuery("k", TimeSpan.FromMinutes(5));
+        await behavior.Handle(new RequestContext<TimedQuery, Result<string>>(request, "user"), Handle);
+        var second = await behavior.Handle(new RequestContext<TimedQuery, Result<string>>(request, "user"), Handle);
+
+        calls.Should().Be(1);
+        second.Value.Should().Be("value-1");
+    }
+
+    [Fact]
+    public void Constructor_Rejects_Null_Dependencies()
+    {
+        var cache = NewCache();
+
+        var nullCache = () => new DistributedCachingBehavior<CachedQuery, Result<string>>(null!, new JsonMediarqCacheSerializer());
+        var nullSerializer = () => new DistributedCachingBehavior<CachedQuery, Result<string>>(cache, null!);
+
+        nullCache.Should().Throw<ArgumentNullException>().WithParameterName("cache");
+        nullSerializer.Should().Throw<ArgumentNullException>().WithParameterName("serializer");
+    }
+
+    [Fact]
+    public async Task Handle_Rejects_Null_Arguments()
+    {
+        var behavior = Behavior(NewCache());
+        var context = new RequestContext<CachedQuery, Result<string>>(new CachedQuery("k"), "user");
+
+        var nullContext = async () => await behavior.Handle(null!, () => Task.FromResult(Result.Success("x")));
+        var nullHandle = async () => await behavior.Handle(context, null!);
+
+        await nullContext.Should().ThrowAsync<ArgumentNullException>().WithParameterName("context");
+        await nullHandle.Should().ThrowAsync<ArgumentNullException>().WithParameterName("handle");
+    }
+
+    [Fact]
+    public void AddMediarqDistributedCaching_Rejects_A_Null_ServiceCollection()
+    {
+        var act = () => ((IServiceCollection)null!).AddMediarqDistributedCaching();
+
+        act.Should().Throw<ArgumentNullException>().WithParameterName("services");
+    }
+
+    [Fact]
+    public void AddMediarqDistributedCaching_Does_Not_Override_A_Custom_Serializer()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IMediarqCacheSerializer, JsonMediarqCacheSerializer>();
+
+        services.AddMediarqDistributedCaching();
+
+        services.Where(d => d.ServiceType == typeof(IMediarqCacheSerializer)).Should().ContainSingle();
+    }
+
+    [Fact]
     public void Json_Serializer_Round_Trips()
     {
         var serializer = new JsonMediarqCacheSerializer();
 
         var bytes = serializer.Serialize("hello");
         serializer.Deserialize<string>(bytes).Should().Be("hello");
+    }
+
+    [Fact]
+    public void Json_Serializer_Round_Trips_A_Result()
+    {
+        var serializer = new JsonMediarqCacheSerializer();
+
+        var bytes = serializer.Serialize(Result.Success("receipt"));
+        var restored = serializer.Deserialize<Result<string>>(bytes);
+
+        restored.Should().NotBeNull();
+        restored!.IsSuccess.Should().BeTrue();
+        restored.Value.Should().Be("receipt");
+    }
+
+    [Fact]
+    public void Json_Serializer_Round_Trips_A_Complex_Dto()
+    {
+        var serializer = new JsonMediarqCacheSerializer();
+
+        var bytes = serializer.Serialize(new OrderDto(7, "Ada", 19.99m));
+        serializer.Deserialize<OrderDto>(bytes).Should().Be(new OrderDto(7, "Ada", 19.99m));
     }
 }

--- a/Tests/Mediarq.Idempotency.Tests/IdempotencyBehaviorTests.cs
+++ b/Tests/Mediarq.Idempotency.Tests/IdempotencyBehaviorTests.cs
@@ -21,6 +21,18 @@ public class IdempotencyBehaviorTests
 
     public record PlainCommand : ICommand<Result<string>>;
 
+    public record TicketCommand(string Key, TimeSpan? Retention) : ICommand<Result<string>>, IIdempotentRequest
+    {
+        public string IdempotencyKey => Key;
+
+        public TimeSpan? IdempotencyDuration => Retention;
+    }
+
+    public record NullableCommand(string Key) : ICommand<string?>, IIdempotentRequest
+    {
+        public string IdempotencyKey => Key;
+    }
+
     private static IDistributedCache NewCache()
         => new MemoryDistributedCache(Options.Create(new MemoryDistributedCacheOptions()));
 
@@ -81,6 +93,75 @@ public class IdempotencyBehaviorTests
     }
 
     [Fact]
+    public async Task Does_Not_Store_A_Null_Response_So_The_Handler_Runs_Again()
+    {
+        var cache = NewCache();
+        var behavior = new IdempotencyBehavior<NullableCommand, string?>(cache, new JsonMediarqCacheSerializer());
+
+        var calls = 0;
+        Task<string?> Handle()
+        {
+            calls++;
+            // First call yields null (must not be stored); later calls yield a value.
+            return Task.FromResult<string?>(calls == 1 ? null : $"value-{calls}");
+        }
+
+        var first = await behavior.Handle(new RequestContext<NullableCommand, string?>(new NullableCommand("k"), "user"), Handle);
+        var second = await behavior.Handle(new RequestContext<NullableCommand, string?>(new NullableCommand("k"), "user"), Handle);
+
+        first.Should().BeNull();
+        second.Should().Be("value-2");
+        calls.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task Honors_A_Custom_IdempotencyDuration_And_Still_Replays()
+    {
+        var cache = NewCache();
+        var behavior = new IdempotencyBehavior<TicketCommand, Result<string>>(cache, new JsonMediarqCacheSerializer());
+
+        var calls = 0;
+        Task<Result<string>> Handle()
+        {
+            calls++;
+            return Task.FromResult(Result.Success($"ticket-{calls}"));
+        }
+
+        var request = new TicketCommand("t-1", TimeSpan.FromMinutes(5));
+        var first = await behavior.Handle(new RequestContext<TicketCommand, Result<string>>(request, "user"), Handle);
+        var second = await behavior.Handle(new RequestContext<TicketCommand, Result<string>>(request, "user"), Handle);
+
+        calls.Should().Be(1);
+        first.Value.Should().Be("ticket-1");
+        second.Value.Should().Be("ticket-1");
+    }
+
+    [Fact]
+    public void Constructor_Rejects_Null_Dependencies()
+    {
+        var cache = NewCache();
+
+        var nullCache = () => new IdempotencyBehavior<PayCommand, Result<string>>(null!, new JsonMediarqCacheSerializer());
+        var nullSerializer = () => new IdempotencyBehavior<PayCommand, Result<string>>(cache, null!);
+
+        nullCache.Should().Throw<ArgumentNullException>().WithParameterName("cache");
+        nullSerializer.Should().Throw<ArgumentNullException>().WithParameterName("serializer");
+    }
+
+    [Fact]
+    public async Task Handle_Rejects_Null_Arguments()
+    {
+        var behavior = Behavior(NewCache());
+        var context = new RequestContext<PayCommand, Result<string>>(new PayCommand("k", 1m), "user");
+
+        var nullContext = async () => await behavior.Handle(null!, () => Task.FromResult(Result.Success("x")));
+        var nullHandle = async () => await behavior.Handle(context, null!);
+
+        await nullContext.Should().ThrowAsync<ArgumentNullException>().WithParameterName("context");
+        await nullHandle.Should().ThrowAsync<ArgumentNullException>().WithParameterName("handle");
+    }
+
+    [Fact]
     public void AddMediarqIdempotency_Registers_Behavior_And_Serializer()
     {
         var services = new ServiceCollection();
@@ -91,5 +172,24 @@ public class IdempotencyBehaviorTests
             && d.ImplementationType == typeof(JsonMediarqCacheSerializer));
         services.Should().Contain(d => d.ServiceType == typeof(IPipelineBehavior<,>)
             && d.ImplementationType == typeof(IdempotencyBehavior<,>));
+    }
+
+    [Fact]
+    public void AddMediarqIdempotency_Rejects_A_Null_ServiceCollection()
+    {
+        var act = () => ((IServiceCollection)null!).AddMediarqIdempotency();
+
+        act.Should().Throw<ArgumentNullException>().WithParameterName("services");
+    }
+
+    [Fact]
+    public void AddMediarqIdempotency_Does_Not_Override_A_Custom_Serializer()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IMediarqCacheSerializer, JsonMediarqCacheSerializer>();
+
+        services.AddMediarqIdempotency();
+
+        services.Where(d => d.ServiceType == typeof(IMediarqCacheSerializer)).Should().ContainSingle();
     }
 }

--- a/Tests/Mediarq.Outbox.Tests/OutboxTests.cs
+++ b/Tests/Mediarq.Outbox.Tests/OutboxTests.cs
@@ -4,6 +4,8 @@ using Mediarq.Core.Common.Requests.Notifications;
 using Mediarq.Core.Mediators;
 using Mediarq.Outbox;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 
 namespace Mediarq.Outbox.Tests;
 
@@ -25,6 +27,14 @@ public sealed class RecordingPublisher : IPublisher
         Published.Enqueue(notification);
         return Task.CompletedTask;
     }
+}
+
+/// <summary>An <see cref="IPublisher"/> that always fails, to exercise the retry/error path.</summary>
+public sealed class ThrowingPublisher : IPublisher
+{
+    public Task Publish<TNotification>(TNotification notification, CancellationToken cancellationToken = default)
+        where TNotification : INotification
+        => Task.FromException(new InvalidOperationException("publish boom"));
 }
 
 public class OutboxTests
@@ -85,5 +95,205 @@ public class OutboxTests
         firstPass.Should().Be(1);
         secondPass.Should().Be(0);
         publisher.Published.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task ProcessPending_Returns_Zero_When_Nothing_Is_Pending()
+    {
+        await using var context = NewContext();
+
+        var processed = await OutboxDispatcher.ProcessPendingAsync(context, new RecordingPublisher(), 50, CancellationToken.None);
+
+        processed.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ProcessPending_Keeps_The_Message_Pending_And_Records_The_Error_When_Publishing_Fails()
+    {
+        await using var context = NewContext();
+        var outbox = new EfCoreOutbox<OutboxTestDbContext>(context);
+        outbox.Enqueue(new OrderPlaced(3));
+        await context.SaveChangesAsync();
+
+        var processed = await OutboxDispatcher.ProcessPendingAsync(context, new ThrowingPublisher(), 50, CancellationToken.None);
+
+        processed.Should().Be(0);
+        var message = await context.Set<OutboxMessage>().SingleAsync();
+        message.ProcessedOnUtc.Should().BeNull();
+        message.Attempts.Should().Be(1);
+        message.Error.Should().Contain("publish boom");
+    }
+
+    [Fact]
+    public async Task ProcessPending_Records_An_Error_When_The_Message_Type_Cannot_Be_Resolved()
+    {
+        await using var context = NewContext();
+        context.Set<OutboxMessage>().Add(new OutboxMessage { Type = "Does.Not.Exist, Nope", Payload = "{}" });
+        await context.SaveChangesAsync();
+
+        var processed = await OutboxDispatcher.ProcessPendingAsync(context, new RecordingPublisher(), 50, CancellationToken.None);
+
+        processed.Should().Be(0);
+        var message = await context.Set<OutboxMessage>().SingleAsync();
+        message.ProcessedOnUtc.Should().BeNull();
+        message.Attempts.Should().Be(1);
+        message.Error.Should().Contain("Does.Not.Exist");
+    }
+
+    [Fact]
+    public async Task ProcessPending_Honors_The_Batch_Size()
+    {
+        await using var context = NewContext();
+        var outbox = new EfCoreOutbox<OutboxTestDbContext>(context);
+        outbox.Enqueue(new OrderPlaced(1));
+        outbox.Enqueue(new OrderPlaced(2));
+        outbox.Enqueue(new OrderPlaced(3));
+        await context.SaveChangesAsync();
+
+        var publisher = new RecordingPublisher();
+        var processed = await OutboxDispatcher.ProcessPendingAsync(context, publisher, batchSize: 2, CancellationToken.None);
+
+        processed.Should().Be(2);
+        publisher.Published.Should().HaveCount(2);
+        var pending = await context.Set<OutboxMessage>().CountAsync(m => m.ProcessedOnUtc == null);
+        pending.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ProcessPending_Publishes_Oldest_First()
+    {
+        await using var context = NewContext();
+        var set = context.Set<OutboxMessage>();
+        set.Add(new OutboxMessage
+        {
+            Type = typeof(OrderPlaced).AssemblyQualifiedName!,
+            Payload = System.Text.Json.JsonSerializer.Serialize(new OrderPlaced(20)),
+            OccurredOnUtc = new DateTime(2026, 1, 2, 0, 0, 0, DateTimeKind.Utc),
+        });
+        set.Add(new OutboxMessage
+        {
+            Type = typeof(OrderPlaced).AssemblyQualifiedName!,
+            Payload = System.Text.Json.JsonSerializer.Serialize(new OrderPlaced(10)),
+            OccurredOnUtc = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+        });
+        await context.SaveChangesAsync();
+
+        var publisher = new RecordingPublisher();
+        await OutboxDispatcher.ProcessPendingAsync(context, publisher, 50, CancellationToken.None);
+
+        publisher.Published.Cast<OrderPlaced>().Select(o => o.OrderId).Should().ContainInOrder(10, 20);
+    }
+
+    [Fact]
+    public void Enqueue_Rejects_A_Null_Notification()
+    {
+        using var context = NewContext();
+        var outbox = new EfCoreOutbox<OutboxTestDbContext>(context);
+
+        var act = () => outbox.Enqueue<OrderPlaced>(null!);
+
+        act.Should().Throw<ArgumentNullException>().WithParameterName("notification");
+    }
+
+    [Fact]
+    public void EfCoreOutbox_Constructor_Rejects_A_Null_Context()
+    {
+        var act = () => new EfCoreOutbox<OutboxTestDbContext>(null!);
+
+        act.Should().Throw<ArgumentNullException>().WithParameterName("context");
+    }
+
+    [Fact]
+    public void ApplyMediarqOutbox_Rejects_A_Null_ModelBuilder()
+    {
+        var act = () => ((ModelBuilder)null!).ApplyMediarqOutbox();
+
+        act.Should().Throw<ArgumentNullException>().WithParameterName("modelBuilder");
+    }
+
+    [Fact]
+    public void OutboxOptions_Have_Sensible_Defaults()
+    {
+        var options = new OutboxOptions();
+
+        options.PollingInterval.Should().Be(TimeSpan.FromSeconds(10));
+        options.BatchSize.Should().Be(50);
+    }
+
+    [Fact]
+    public void AddMediarqOutbox_Registers_The_Outbox_Processor_And_Options()
+    {
+        var services = new ServiceCollection();
+        services.AddDbContext<OutboxTestDbContext>(o => o.UseInMemoryDatabase("reg"));
+
+        services.AddMediarqOutbox<OutboxTestDbContext>(o => o.BatchSize = 7);
+
+        services.Should().Contain(d => d.ServiceType == typeof(IOutbox)
+            && d.ImplementationType == typeof(EfCoreOutbox<OutboxTestDbContext>)
+            && d.Lifetime == ServiceLifetime.Scoped);
+        services.Should().Contain(d => d.ServiceType == typeof(IHostedService));
+
+        using var provider = services.BuildServiceProvider();
+        provider.GetRequiredService<OutboxOptions>().BatchSize.Should().Be(7);
+    }
+
+    [Fact]
+    public void AddMediarqOutbox_Rejects_A_Null_ServiceCollection()
+    {
+        var act = () => ((IServiceCollection)null!).AddMediarqOutbox<OutboxTestDbContext>();
+
+        act.Should().Throw<ArgumentNullException>().WithParameterName("services");
+    }
+
+    [Fact]
+    public async Task OutboxProcessor_Publishes_Pending_Messages_While_Running()
+    {
+        var publisher = new RecordingPublisher();
+        var services = new ServiceCollection();
+        services.AddSingleton<IPublisher>(publisher);
+        services.AddDbContext<OutboxTestDbContext>(o => o.UseInMemoryDatabase("processor-run"));
+        services.AddMediarqOutbox<OutboxTestDbContext>(o => o.PollingInterval = TimeSpan.FromMilliseconds(20));
+
+        using var provider = services.BuildServiceProvider();
+
+        using (var scope = provider.CreateScope())
+        {
+            var context = scope.ServiceProvider.GetRequiredService<OutboxTestDbContext>();
+            scope.ServiceProvider.GetRequiredService<IOutbox>().Enqueue(new OrderPlaced(99));
+            await context.SaveChangesAsync();
+        }
+
+        var processor = provider.GetServices<IHostedService>().OfType<OutboxProcessor<OutboxTestDbContext>>().Single();
+        await processor.StartAsync(CancellationToken.None);
+
+        try
+        {
+            var deadline = DateTime.UtcNow.AddSeconds(5);
+            while (publisher.Published.IsEmpty && DateTime.UtcNow < deadline)
+            {
+                await Task.Delay(20);
+            }
+        }
+        finally
+        {
+            await processor.StopAsync(CancellationToken.None);
+        }
+
+        publisher.Published.Should().ContainSingle().Which.Should().BeOfType<OrderPlaced>()
+            .Which.OrderId.Should().Be(99);
+    }
+
+    [Fact]
+    public void OutboxProcessor_Constructor_Rejects_Null_Dependencies()
+    {
+        var services = new ServiceCollection();
+        using var provider = services.BuildServiceProvider();
+        var scopeFactory = provider.GetRequiredService<IServiceScopeFactory>();
+
+        var nullScopeFactory = () => new OutboxProcessor<OutboxTestDbContext>(null!, new OutboxOptions());
+        var nullOptions = () => new OutboxProcessor<OutboxTestDbContext>(scopeFactory, null!);
+
+        nullScopeFactory.Should().Throw<ArgumentNullException>().WithParameterName("scopeFactory");
+        nullOptions.Should().Throw<ArgumentNullException>().WithParameterName("options");
     }
 }


### PR DESCRIPTION
## v1.1 — Reliability building blocks: raise test coverage

Brings the three v1.1 reliability packages (`Mediarq.Idempotency`, `Mediarq.Outbox`, `Mediarq.Caching`)
to release-quality test coverage before release. Code, docs and CHANGELOG entries for these packages were
already in place; the open roadmap item was test coverage. **Tests only — no production code changes.**

### Idempotency (4 → 10 tests)
- Null result is not stored (handler re-runs), custom `IdempotencyDuration`.
- Constructor / `Handle` argument guards, `AddMediarqIdempotency` null guard, custom-serializer preservation.

### Outbox (3 → 16 tests)
- Publish failure keeps the message pending and records the error/attempt; unresolvable message type.
- Batch-size limiting, oldest-first ordering, empty pass.
- `Enqueue` / ctor / `ApplyMediarqOutbox` / `AddMediarqOutbox` guards, `OutboxOptions` defaults, DI registration.
- Full `OutboxProcessor` start → publish → stop lifecycle.

### Caching (3 → 21 tests across both behaviors)
- Cache miss on a different key, null-result handling and custom `CacheDuration` for the in-memory and
  distributed behaviors.
- Argument and service-collection guards.
- Explicit `Result<T>` and complex-DTO JSON round-trips for the distributed serializer.

### Notes
- A failing publisher double must return a faulted task (`Task.FromException`) rather than throw
  synchronously, otherwise the dispatcher's reflection wraps it in `TargetInvocationException`.

**Result:** 47 tests green (10 + 16 + 21).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
