### PR TITLE
build: wire PublicApiAnalyzers and document the SemVer policy

### DIFF
--- a/docs/guides/versioning.md
+++ b/docs/guides/versioning.md
@@ -1,0 +1,59 @@
+# Versioning & public API policy
+
+Mediarq is a set of NuGet libraries. Every package follows [Semantic Versioning](https://semver.org/):
+`MAJOR.MINOR.PATCH`.
+
+- **MAJOR** — a breaking change: a public API signature or behavior changes in a way that can break a
+  consumer at compile time or at runtime (renamed/removed public type or member, changed pipeline
+  ordering, a behavior that now runs where it didn't before, ...).
+- **MINOR** — a backward-compatible addition: a new package, a new public type/member, a new optional
+  overload.
+- **PATCH** — a backward-compatible bug fix: no public API change.
+
+All packages are at `Version 1.0.0`: the public API (the `Mediarq.*` namespaces exposed by each package)
+is **frozen**. See [`docs/BRANCHING.md`](../../docs/BRANCHING.md#api-publique--rappel) for the merge-time
+rule — no public renaming/signature change lands on `dev` without an assumed major bump.
+
+## Enforcement: PublicApiAnalyzers
+
+Every package under `src/` references
+[`Microsoft.CodeAnalysis.PublicApiAnalyzers`](https://github.com/dotnet/roslyn-analyzers/blob/main/src/PublicApiAnalyzers/PublicApiAnalyzers.Help.md)
+(wired once for all packages via [`src/Directory.Build.props`](../../src/Directory.Build.props)). Each
+package carries two files next to its `.csproj`:
+
+- **`PublicAPI.Shipped.txt`** — the public API surface of the last **released** version. Treat this file
+  like a changelog: once a version ships, its entries move here and stay.
+- **`PublicAPI.Unshipped.txt`** — public API added since the last release, not yet shipped.
+
+The analyzer flags, at build time (as a warning, visible in the IDE — it does not fail the build):
+
+- **`RS0016`** — a public type/member was added but isn't listed in either file yet. The IDE offers a
+  code fix ("Add to public API") that appends the exact signature to `PublicAPI.Unshipped.txt`.
+- **`RS0017`** — a symbol is listed in one of the files but no longer exists in the code (removed or
+  renamed public API — a signal to think about whether that's a MAJOR change).
+- **`RS0037`** — a `PublicAPI.*.txt` file is missing the `#nullable enable` marker (nullability
+  annotations wouldn't be tracked).
+
+## Workflow
+
+1. **Add public API** (new type, new member, new optional parameter): build the project. The analyzer
+   flags `RS0016`; use the IDE lightbulb ("Add all items to the public API files") or run
+   ```bash
+   dotnet format analyzers src/<Package>/<Package>.csproj --diagnostics RS0016 --severity info
+   ```
+   from the repo root. The entries land in that package's `PublicAPI.Unshipped.txt`.
+2. **Remove or rename public API**: the analyzer flags `RS0017` for the stale entry. Removing it from
+   `PublicAPI.Unshipped.txt` (if unreleased) is a non-breaking cleanup; removing it from
+   `PublicAPI.Shipped.txt` means you are shipping a **breaking change** — bump `MAJOR` and call it out
+   explicitly in the PR description (see `docs/BRANCHING.md`).
+3. **On release** (tag pushed, package published to NuGet): fold that package's
+   `PublicAPI.Unshipped.txt` entries into `PublicAPI.Shipped.txt` and reset `Unshipped.txt` to just the
+   `#nullable enable` header — the same move performed once, by hand, to seed the `v1.0.0` baseline for
+   every package in this repo.
+
+## Why "via IDE" and not a CI gate
+
+The analyzer runs as part of every `dotnet build`, so the warning is visible locally and in CI logs, but
+it does not fail the build — the goal is a deliberate, visible prompt when public API changes, not a hard
+gate that blocks work-in-progress branches. Reviewers still eyeball public API diffs on any PR that
+touches a `src/*/PublicAPI.*.txt` file.

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,6 +37,7 @@ New here? Start with **Concepts**, then build **Your first app**.
 - [Testing](guides/testing.md) — unit- and integration-test handlers, validators, behaviors
 - [Migrating from MediatR](guides/migrating-from-mediatr.md)
 - [Native AOT & trimming](guides/native-aot.md)
+- [Versioning & public API policy](guides/versioning.md) — SemVer rules and the `PublicAPI.*.txt` workflow
 - [Troubleshooting](guides/troubleshooting.md) — when something silently doesn't fire
 
 ## Getting started

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -18,6 +18,8 @@
       href: guides/mediatr-parity.md
     - name: Native AOT & trimming
       href: guides/native-aot.md
+    - name: Versioning & public API policy
+      href: guides/versioning.md
     - name: Troubleshooting
       href: guides/troubleshooting.md
 - name: API

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,0 +1,13 @@
+<Project>
+
+  <!--
+    Applies to every package under src/. Tracks each package's public API surface in
+    PublicAPI.Shipped.txt / PublicAPI.Unshipped.txt (RS0016/RS0017), so an accidental public API
+    change is caught at build time instead of silently breaking SemVer for consumers.
+    See docs/guides/versioning.md for the workflow.
+  -->
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4" PrivateAssets="all" />
+  </ItemGroup>
+
+</Project>

--- a/src/Mediarq.Analyzers/PublicAPI.Shipped.txt
+++ b/src/Mediarq.Analyzers/PublicAPI.Shipped.txt
@@ -1,0 +1,11 @@
+#nullable enable
+Mediarq.Analyzers.MediatRMigrationAnalyzer
+Mediarq.Analyzers.MediatRMigrationAnalyzer.MediatRMigrationAnalyzer() -> void
+Mediarq.Analyzers.MediatRMigrationCodeFixProvider
+Mediarq.Analyzers.MediatRMigrationCodeFixProvider.MediatRMigrationCodeFixProvider() -> void
+const Mediarq.Analyzers.MediatRMigrationAnalyzer.DiagnosticId = "MQ100" -> string!
+override Mediarq.Analyzers.MediatRMigrationAnalyzer.Initialize(Microsoft.CodeAnalysis.Diagnostics.AnalysisContext! context) -> void
+override Mediarq.Analyzers.MediatRMigrationAnalyzer.SupportedDiagnostics.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.DiagnosticDescriptor!>
+override Mediarq.Analyzers.MediatRMigrationCodeFixProvider.FixableDiagnosticIds.get -> System.Collections.Immutable.ImmutableArray<string!>
+override Mediarq.Analyzers.MediatRMigrationCodeFixProvider.GetFixAllProvider() -> Microsoft.CodeAnalysis.CodeFixes.FixAllProvider!
+override Mediarq.Analyzers.MediatRMigrationCodeFixProvider.RegisterCodeFixesAsync(Microsoft.CodeAnalysis.CodeFixes.CodeFixContext context) -> System.Threading.Tasks.Task!

--- a/src/Mediarq.Analyzers/PublicAPI.Unshipped.txt
+++ b/src/Mediarq.Analyzers/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Mediarq.AspNetCore/PublicAPI.Shipped.txt
+++ b/src/Mediarq.AspNetCore/PublicAPI.Shipped.txt
@@ -1,0 +1,12 @@
+#nullable enable
+Mediarq.AspNetCore.ResultActionResultExtensions
+Mediarq.AspNetCore.ResultHttpExtensions
+static Mediarq.AspNetCore.ResultActionResultExtensions.ToActionResult(this Mediarq.Core.Common.Results.Result! result, System.Action<Microsoft.AspNetCore.Mvc.ProblemDetails!>? configureProblem = null) -> Microsoft.AspNetCore.Mvc.IActionResult!
+static Mediarq.AspNetCore.ResultActionResultExtensions.ToActionResult<T>(this Mediarq.Core.Common.Results.Result<T>! result, System.Action<Microsoft.AspNetCore.Mvc.ProblemDetails!>? configureProblem = null) -> Microsoft.AspNetCore.Mvc.IActionResult!
+static Mediarq.AspNetCore.ResultActionResultExtensions.ToActionResultAsync(this System.Threading.Tasks.Task<Mediarq.Core.Common.Results.Result!>! resultTask, System.Action<Microsoft.AspNetCore.Mvc.ProblemDetails!>? configureProblem = null) -> System.Threading.Tasks.Task<Microsoft.AspNetCore.Mvc.IActionResult!>!
+static Mediarq.AspNetCore.ResultActionResultExtensions.ToActionResultAsync<T>(this System.Threading.Tasks.Task<Mediarq.Core.Common.Results.Result<T>!>! resultTask, System.Action<Microsoft.AspNetCore.Mvc.ProblemDetails!>? configureProblem = null) -> System.Threading.Tasks.Task<Microsoft.AspNetCore.Mvc.IActionResult!>!
+static Mediarq.AspNetCore.ResultHttpExtensions.ToHttpResult(this Mediarq.Core.Common.Results.Result! result) -> Microsoft.AspNetCore.Http.IResult!
+static Mediarq.AspNetCore.ResultHttpExtensions.ToHttpResult<T>(this Mediarq.Core.Common.Results.Result<T>! result) -> Microsoft.AspNetCore.Http.IResult!
+static Mediarq.AspNetCore.ResultHttpExtensions.ToHttpResultAsync(this System.Threading.Tasks.Task<Mediarq.Core.Common.Results.Result!>! resultTask) -> System.Threading.Tasks.Task<Microsoft.AspNetCore.Http.IResult!>!
+static Mediarq.AspNetCore.ResultHttpExtensions.ToHttpResultAsync<T>(this System.Threading.Tasks.Task<Mediarq.Core.Common.Results.Result<T>!>! resultTask) -> System.Threading.Tasks.Task<Microsoft.AspNetCore.Http.IResult!>!
+static Mediarq.AspNetCore.ResultHttpExtensions.ToStatusCode(this Mediarq.Core.Common.Results.ErrorType errorType) -> int

--- a/src/Mediarq.AspNetCore/PublicAPI.Unshipped.txt
+++ b/src/Mediarq.AspNetCore/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Mediarq.Caching/PublicAPI.Shipped.txt
+++ b/src/Mediarq.Caching/PublicAPI.Shipped.txt
@@ -1,0 +1,22 @@
+#nullable enable
+Mediarq.Caching.CachingBehavior<TRequest, TResponse>
+Mediarq.Caching.CachingBehavior<TRequest, TResponse>.CachingBehavior(Microsoft.Extensions.Caching.Memory.IMemoryCache! cache) -> void
+Mediarq.Caching.CachingBehavior<TRequest, TResponse>.Handle(Mediarq.Core.Common.Contexts.IMutableRequestContext<TRequest, TResponse>! context, System.Func<System.Threading.Tasks.Task<TResponse>!>! handle, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<TResponse>!
+Mediarq.Caching.CachingBehavior<TRequest, TResponse>.IsActive.get -> bool
+Mediarq.Caching.CachingServiceCollectionExtensions
+Mediarq.Caching.DistributedCachingBehavior<TRequest, TResponse>
+Mediarq.Caching.DistributedCachingBehavior<TRequest, TResponse>.DistributedCachingBehavior(Microsoft.Extensions.Caching.Distributed.IDistributedCache! cache, Mediarq.Caching.IMediarqCacheSerializer! serializer) -> void
+Mediarq.Caching.DistributedCachingBehavior<TRequest, TResponse>.Handle(Mediarq.Core.Common.Contexts.IMutableRequestContext<TRequest, TResponse>! context, System.Func<System.Threading.Tasks.Task<TResponse>!>! handle, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<TResponse>!
+Mediarq.Caching.DistributedCachingBehavior<TRequest, TResponse>.IsActive.get -> bool
+Mediarq.Caching.ICacheableRequest
+Mediarq.Caching.ICacheableRequest.CacheDuration.get -> System.TimeSpan?
+Mediarq.Caching.ICacheableRequest.CacheKey.get -> string!
+Mediarq.Caching.IMediarqCacheSerializer
+Mediarq.Caching.IMediarqCacheSerializer.Deserialize<TValue>(byte[]! data) -> TValue?
+Mediarq.Caching.IMediarqCacheSerializer.Serialize<TValue>(TValue value) -> byte[]!
+Mediarq.Caching.JsonMediarqCacheSerializer
+Mediarq.Caching.JsonMediarqCacheSerializer.Deserialize<TValue>(byte[]! data) -> TValue?
+Mediarq.Caching.JsonMediarqCacheSerializer.JsonMediarqCacheSerializer() -> void
+Mediarq.Caching.JsonMediarqCacheSerializer.Serialize<TValue>(TValue value) -> byte[]!
+static Mediarq.Caching.CachingServiceCollectionExtensions.AddMediarqCaching(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static Mediarq.Caching.CachingServiceCollectionExtensions.AddMediarqDistributedCaching(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!

--- a/src/Mediarq.Caching/PublicAPI.Unshipped.txt
+++ b/src/Mediarq.Caching/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Mediarq.Core/PublicAPI.Shipped.txt
+++ b/src/Mediarq.Core/PublicAPI.Shipped.txt
@@ -1,0 +1,311 @@
+#nullable enable
+Mediarq.Core.Common.Contexts.IMutableRequestContext<TRequest, TResponse>
+Mediarq.Core.Common.Contexts.IMutableRequestContext<TRequest, TResponse>.AddItem(string! key, object! value) -> void
+Mediarq.Core.Common.Contexts.IMutableRequestContext<TRequest, TResponse>.RemoveItem(string! key) -> bool
+Mediarq.Core.Common.Contexts.IMutableRequestContext<TRequest, TResponse>.TryGetItem<T>(string! key, out T value) -> bool
+Mediarq.Core.Common.Contexts.IRequestContext<TRequest, TResponse>
+Mediarq.Core.Common.Contexts.IRequestContext<TRequest, TResponse>.CancellationToken.get -> System.Threading.CancellationToken
+Mediarq.Core.Common.Contexts.IRequestContext<TRequest, TResponse>.CorrelationId.get -> System.Guid
+Mediarq.Core.Common.Contexts.IRequestContext<TRequest, TResponse>.FinishedAt.get -> System.DateTime
+Mediarq.Core.Common.Contexts.IRequestContext<TRequest, TResponse>.FinishedAt.set -> void
+Mediarq.Core.Common.Contexts.IRequestContext<TRequest, TResponse>.Items.get -> System.Collections.Generic.IReadOnlyDictionary<string!, object!>!
+Mediarq.Core.Common.Contexts.IRequestContext<TRequest, TResponse>.Request.get -> TRequest
+Mediarq.Core.Common.Contexts.IRequestContext<TRequest, TResponse>.RequestId.get -> System.Guid
+Mediarq.Core.Common.Contexts.IRequestContext<TRequest, TResponse>.StartedAt.get -> System.DateTime
+Mediarq.Core.Common.Contexts.IRequestContext<TRequest, TResponse>.UserId.get -> string?
+Mediarq.Core.Common.Contexts.IRequestContextFactory
+Mediarq.Core.Common.Contexts.IRequestContextFactory.Create<TRequest, TResponse>(TRequest request, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> Mediarq.Core.Common.Contexts.RequestContext<TRequest, TResponse>!
+Mediarq.Core.Common.Contexts.RequestContext<TRequest, TResponse>
+Mediarq.Core.Common.Contexts.RequestContext<TRequest, TResponse>.AddItem(string! key, object! value) -> void
+Mediarq.Core.Common.Contexts.RequestContext<TRequest, TResponse>.CancellationToken.get -> System.Threading.CancellationToken
+Mediarq.Core.Common.Contexts.RequestContext<TRequest, TResponse>.CancellationToken.init -> void
+Mediarq.Core.Common.Contexts.RequestContext<TRequest, TResponse>.CorrelationId.get -> System.Guid
+Mediarq.Core.Common.Contexts.RequestContext<TRequest, TResponse>.CorrelationId.init -> void
+Mediarq.Core.Common.Contexts.RequestContext<TRequest, TResponse>.Duration.get -> System.TimeSpan
+Mediarq.Core.Common.Contexts.RequestContext<TRequest, TResponse>.FinishedAt.get -> System.DateTime
+Mediarq.Core.Common.Contexts.RequestContext<TRequest, TResponse>.FinishedAt.set -> void
+Mediarq.Core.Common.Contexts.RequestContext<TRequest, TResponse>.Items.get -> System.Collections.Generic.IReadOnlyDictionary<string!, object!>!
+Mediarq.Core.Common.Contexts.RequestContext<TRequest, TResponse>.RemoveItem(string! key) -> bool
+Mediarq.Core.Common.Contexts.RequestContext<TRequest, TResponse>.Request.get -> TRequest
+Mediarq.Core.Common.Contexts.RequestContext<TRequest, TResponse>.Request.init -> void
+Mediarq.Core.Common.Contexts.RequestContext<TRequest, TResponse>.RequestContext(TRequest request, string? userId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> void
+Mediarq.Core.Common.Contexts.RequestContext<TRequest, TResponse>.RequestId.get -> System.Guid
+Mediarq.Core.Common.Contexts.RequestContext<TRequest, TResponse>.RequestId.init -> void
+Mediarq.Core.Common.Contexts.RequestContext<TRequest, TResponse>.StartedAt.get -> System.DateTime
+Mediarq.Core.Common.Contexts.RequestContext<TRequest, TResponse>.StartedAt.init -> void
+Mediarq.Core.Common.Contexts.RequestContext<TRequest, TResponse>.TryGetItem<T>(string! key, out T value) -> bool
+Mediarq.Core.Common.Contexts.RequestContext<TRequest, TResponse>.UserId.get -> string?
+Mediarq.Core.Common.Contexts.RequestContext<TRequest, TResponse>.UserId.init -> void
+Mediarq.Core.Common.Contexts.RequestContextFactory
+Mediarq.Core.Common.Contexts.RequestContextFactory.Create<TRequest, TResponse>(TRequest request, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> Mediarq.Core.Common.Contexts.RequestContext<TRequest, TResponse>!
+Mediarq.Core.Common.Contexts.RequestContextFactory.RequestContextFactory(Mediarq.Core.Common.User.IUserContext! userContext) -> void
+Mediarq.Core.Common.Exceptions.HandlerNotFoundException
+Mediarq.Core.Common.Exceptions.HandlerNotFoundException.HandlerNotFoundException(System.Type! requestType) -> void
+Mediarq.Core.Common.Exceptions.MediarqException
+Mediarq.Core.Common.Exceptions.MediarqException.MediarqException(string! message) -> void
+Mediarq.Core.Common.Exceptions.RequestTimeoutException
+Mediarq.Core.Common.Exceptions.RequestTimeoutException.RequestTimeoutException(System.Type! requestType, System.TimeSpan timeout) -> void
+Mediarq.Core.Common.Exceptions.RequestTimeoutException.RequestType.get -> System.Type!
+Mediarq.Core.Common.Exceptions.RequestTimeoutException.Timeout.get -> System.TimeSpan
+Mediarq.Core.Common.Pipeline.Behaviors.LoggingBehavior<TRequest, TResponse>
+Mediarq.Core.Common.Pipeline.Behaviors.LoggingBehavior<TRequest, TResponse>.Handle(Mediarq.Core.Common.Contexts.IMutableRequestContext<TRequest, TResponse>! context, System.Func<System.Threading.Tasks.Task<TResponse>!>! handle, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<TResponse>!
+Mediarq.Core.Common.Pipeline.Behaviors.LoggingBehavior<TRequest, TResponse>.IsActive.get -> bool
+Mediarq.Core.Common.Pipeline.Behaviors.LoggingBehavior<TRequest, TResponse>.LoggingBehavior(Microsoft.Extensions.Logging.ILogger<Mediarq.Core.Common.Pipeline.Behaviors.LoggingBehavior<TRequest, TResponse>!>! logger) -> void
+Mediarq.Core.Common.Pipeline.Behaviors.PerformanceBehavior<TRequest, TResponse>
+Mediarq.Core.Common.Pipeline.Behaviors.PerformanceBehavior<TRequest, TResponse>.Handle(Mediarq.Core.Common.Contexts.IMutableRequestContext<TRequest, TResponse>! context, System.Func<System.Threading.Tasks.Task<TResponse>!>! handle, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<TResponse>!
+Mediarq.Core.Common.Pipeline.Behaviors.PerformanceBehavior<TRequest, TResponse>.IsActive.get -> bool
+Mediarq.Core.Common.Pipeline.Behaviors.PerformanceBehavior<TRequest, TResponse>.PerformanceBehavior(Microsoft.Extensions.Logging.ILogger<Mediarq.Core.Common.Pipeline.Behaviors.PerformanceBehavior<TRequest, TResponse>!>! logger, Mediarq.Core.Common.Time.IClock! clock) -> void
+Mediarq.Core.Common.Pipeline.Behaviors.RequestExceptionProcessorBehavior<TRequest, TResponse>
+Mediarq.Core.Common.Pipeline.Behaviors.RequestExceptionProcessorBehavior<TRequest, TResponse>.Handle(Mediarq.Core.Common.Contexts.IMutableRequestContext<TRequest, TResponse>! context, System.Func<System.Threading.Tasks.Task<TResponse>!>! handle, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<TResponse>!
+Mediarq.Core.Common.Pipeline.Behaviors.RequestExceptionProcessorBehavior<TRequest, TResponse>.IsActive.get -> bool
+Mediarq.Core.Common.Pipeline.Behaviors.RequestExceptionProcessorBehavior<TRequest, TResponse>.Order.get -> int
+Mediarq.Core.Common.Pipeline.Behaviors.RequestExceptionProcessorBehavior<TRequest, TResponse>.RequestExceptionProcessorBehavior(System.Collections.Generic.IEnumerable<Mediarq.Core.Common.Requests.Exceptions.IRequestExceptionHandler<TRequest, TResponse>!>! exceptionHandlers) -> void
+Mediarq.Core.Common.Pipeline.Behaviors.RequestPostProcessorBehavior<TRequest, TResponse>
+Mediarq.Core.Common.Pipeline.Behaviors.RequestPostProcessorBehavior<TRequest, TResponse>.Handle(Mediarq.Core.Common.Contexts.IMutableRequestContext<TRequest, TResponse>! context, System.Func<System.Threading.Tasks.Task<TResponse>!>! handle, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<TResponse>!
+Mediarq.Core.Common.Pipeline.Behaviors.RequestPostProcessorBehavior<TRequest, TResponse>.IsActive.get -> bool
+Mediarq.Core.Common.Pipeline.Behaviors.RequestPostProcessorBehavior<TRequest, TResponse>.RequestPostProcessorBehavior(System.Collections.Generic.IEnumerable<Mediarq.Core.Common.Requests.Processors.IRequestPostProcessor<TRequest, TResponse>!>! postProcessors) -> void
+Mediarq.Core.Common.Pipeline.Behaviors.RequestPreProcessorBehavior<TRequest, TResponse>
+Mediarq.Core.Common.Pipeline.Behaviors.RequestPreProcessorBehavior<TRequest, TResponse>.Handle(Mediarq.Core.Common.Contexts.IMutableRequestContext<TRequest, TResponse>! context, System.Func<System.Threading.Tasks.Task<TResponse>!>! handle, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<TResponse>!
+Mediarq.Core.Common.Pipeline.Behaviors.RequestPreProcessorBehavior<TRequest, TResponse>.IsActive.get -> bool
+Mediarq.Core.Common.Pipeline.Behaviors.RequestPreProcessorBehavior<TRequest, TResponse>.RequestPreProcessorBehavior(System.Collections.Generic.IEnumerable<Mediarq.Core.Common.Requests.Processors.IRequestPreProcessor<TRequest>!>! preProcessors) -> void
+Mediarq.Core.Common.Pipeline.Behaviors.TimeoutBehavior<TRequest, TResponse>
+Mediarq.Core.Common.Pipeline.Behaviors.TimeoutBehavior<TRequest, TResponse>.Handle(Mediarq.Core.Common.Contexts.IMutableRequestContext<TRequest, TResponse>! context, System.Func<System.Threading.Tasks.Task<TResponse>!>! handle, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<TResponse>!
+Mediarq.Core.Common.Pipeline.Behaviors.TimeoutBehavior<TRequest, TResponse>.IsActive.get -> bool
+Mediarq.Core.Common.Pipeline.Behaviors.TimeoutBehavior<TRequest, TResponse>.Order.get -> int
+Mediarq.Core.Common.Pipeline.Behaviors.TimeoutBehavior<TRequest, TResponse>.TimeoutBehavior() -> void
+Mediarq.Core.Common.Pipeline.Behaviors.ValidationBehavior<TRequest, TResponse>
+Mediarq.Core.Common.Pipeline.Behaviors.ValidationBehavior<TRequest, TResponse>.Handle(Mediarq.Core.Common.Contexts.IMutableRequestContext<TRequest, TResponse>! context, System.Func<System.Threading.Tasks.Task<TResponse>!>! handle, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<TResponse>!
+Mediarq.Core.Common.Pipeline.Behaviors.ValidationBehavior<TRequest, TResponse>.IsActive.get -> bool
+Mediarq.Core.Common.Pipeline.Behaviors.ValidationBehavior<TRequest, TResponse>.ValidationBehavior(System.Collections.Generic.IEnumerable<Mediarq.Core.Common.Requests.Validators.IValidator<TRequest>!>! validators, Mediarq.Core.Common.Requests.Validators.IValidationMessageResolver? messageResolver = null) -> void
+Mediarq.Core.Common.Pipeline.Behaviors.ValidationFailureRegistry
+Mediarq.Core.Common.Pipeline.IConditionalPipelineBehavior
+Mediarq.Core.Common.Pipeline.IConditionalPipelineBehavior.IsActive.get -> bool
+Mediarq.Core.Common.Pipeline.IOrderBehavior
+Mediarq.Core.Common.Pipeline.IOrderBehavior.Order.get -> int
+Mediarq.Core.Common.Pipeline.IPipelineBehavior<TRequest, TResponse>
+Mediarq.Core.Common.Pipeline.IPipelineBehavior<TRequest, TResponse>.Handle(Mediarq.Core.Common.Contexts.IMutableRequestContext<TRequest, TResponse>! context, System.Func<System.Threading.Tasks.Task<TResponse>!>! handle, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<TResponse>!
+Mediarq.Core.Common.Pipeline.IPipelineExecutor
+Mediarq.Core.Common.Pipeline.IPipelineExecutor.ExecuteAsync<TRequest, TResponse>(Mediarq.Core.Common.Contexts.RequestContext<TRequest, TResponse>! context, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<TResponse>!>! handlerDelegate, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<TResponse>!
+Mediarq.Core.Common.Pipeline.IPipelineExecutor.ExecuteAsync<TRequest, TResponse>(TRequest request, Mediarq.Core.Common.Requests.Abstraction.IRequestHandler<TRequest, TResponse>! handler, Mediarq.Core.Common.Contexts.IRequestContextFactory! contextFactory, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<TResponse>!
+Mediarq.Core.Common.Pipeline.IStreamPipelineBehavior<TRequest, TResponse>
+Mediarq.Core.Common.Pipeline.IStreamPipelineBehavior<TRequest, TResponse>.Handle(TRequest request, System.Func<System.Collections.Generic.IAsyncEnumerable<TResponse>!>! continuation, System.Threading.CancellationToken cancellationToken) -> System.Collections.Generic.IAsyncEnumerable<TResponse>!
+Mediarq.Core.Common.Pipeline.IStreamPipelineExecutor
+Mediarq.Core.Common.Pipeline.IStreamPipelineExecutor.Execute<TRequest, TResponse>(TRequest request, System.Func<System.Collections.Generic.IAsyncEnumerable<TResponse>!>! handler, System.Threading.CancellationToken cancellationToken) -> System.Collections.Generic.IAsyncEnumerable<TResponse>!
+Mediarq.Core.Common.Pipeline.PipelineExecutor
+Mediarq.Core.Common.Pipeline.PipelineExecutor.ExecuteAsync<TRequest, TResponse>(Mediarq.Core.Common.Contexts.RequestContext<TRequest, TResponse>! context, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<TResponse>!>! handlerDelegate, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<TResponse>!
+Mediarq.Core.Common.Pipeline.PipelineExecutor.ExecuteAsync<TRequest, TResponse>(TRequest request, Mediarq.Core.Common.Requests.Abstraction.IRequestHandler<TRequest, TResponse>! handler, Mediarq.Core.Common.Contexts.IRequestContextFactory! contextFactory, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<TResponse>!
+Mediarq.Core.Common.Pipeline.PipelineExecutor.PipelineExecutor(Mediarq.Core.Common.Resolvers.IHandlerResolver! handlerResolver) -> void
+Mediarq.Core.Common.Pipeline.StreamPipelineExecutor
+Mediarq.Core.Common.Pipeline.StreamPipelineExecutor.Execute<TRequest, TResponse>(TRequest request, System.Func<System.Collections.Generic.IAsyncEnumerable<TResponse>!>! handler, System.Threading.CancellationToken cancellationToken) -> System.Collections.Generic.IAsyncEnumerable<TResponse>!
+Mediarq.Core.Common.Pipeline.StreamPipelineExecutor.StreamPipelineExecutor(Mediarq.Core.Common.Resolvers.IHandlerResolver! handlerResolver) -> void
+Mediarq.Core.Common.Registration.RegisterHandlerAttribute
+Mediarq.Core.Common.Registration.RegisterHandlerAttribute.Lifetime.get -> Microsoft.Extensions.DependencyInjection.ServiceLifetime
+Mediarq.Core.Common.Registration.RegisterHandlerAttribute.RegisterHandlerAttribute(Microsoft.Extensions.DependencyInjection.ServiceLifetime lifetime = Microsoft.Extensions.DependencyInjection.ServiceLifetime.Scoped) -> void
+Mediarq.Core.Common.Requests.Abstraction.ICommandOrQuery<TResponse>
+Mediarq.Core.Common.Requests.Abstraction.IRequest
+Mediarq.Core.Common.Requests.Abstraction.IRequest<TResponse>
+Mediarq.Core.Common.Requests.Abstraction.IRequestHandler<TRequest, TResponse>
+Mediarq.Core.Common.Requests.Abstraction.IRequestHandler<TRequest, TResponse>.Handle(TRequest request, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<TResponse>!
+Mediarq.Core.Common.Requests.Abstraction.IRequestHandler<TRequest>
+Mediarq.Core.Common.Requests.Abstraction.IRequestHandler<TRequest>.Handle(TRequest request, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Mediarq.Core.Common.Requests.Abstraction.ITimeoutRequest
+Mediarq.Core.Common.Requests.Abstraction.ITimeoutRequest.Timeout.get -> System.TimeSpan
+Mediarq.Core.Common.Requests.Abstraction.Unit
+Mediarq.Core.Common.Requests.Abstraction.Unit.Equals(Mediarq.Core.Common.Requests.Abstraction.Unit other) -> bool
+Mediarq.Core.Common.Requests.Abstraction.Unit.Unit() -> void
+Mediarq.Core.Common.Requests.Command.ICommand
+Mediarq.Core.Common.Requests.Command.ICommand<TResponse>
+Mediarq.Core.Common.Requests.Command.ICommandHandler<TRequest, TResponse>
+Mediarq.Core.Common.Requests.Command.ICommandHandler<TRequest>
+Mediarq.Core.Common.Requests.Exceptions.IRequestExceptionHandler<TRequest, TResponse>
+Mediarq.Core.Common.Requests.Exceptions.IRequestExceptionHandler<TRequest, TResponse>.Handle(TRequest request, System.Exception! exception, Mediarq.Core.Common.Requests.Exceptions.RequestExceptionHandlerState<TResponse>! state, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Mediarq.Core.Common.Requests.Exceptions.RequestExceptionHandlerState<TResponse>
+Mediarq.Core.Common.Requests.Exceptions.RequestExceptionHandlerState<TResponse>.Handled.get -> bool
+Mediarq.Core.Common.Requests.Exceptions.RequestExceptionHandlerState<TResponse>.RequestExceptionHandlerState() -> void
+Mediarq.Core.Common.Requests.Exceptions.RequestExceptionHandlerState<TResponse>.Response.get -> TResponse?
+Mediarq.Core.Common.Requests.Exceptions.RequestExceptionHandlerState<TResponse>.SetHandled(TResponse response) -> void
+Mediarq.Core.Common.Requests.Notifications.AggregateExceptionNotificationPublisher
+Mediarq.Core.Common.Requests.Notifications.AggregateExceptionNotificationPublisher.AggregateExceptionNotificationPublisher() -> void
+Mediarq.Core.Common.Requests.Notifications.AggregateExceptionNotificationPublisher.Publish(System.Collections.Generic.IReadOnlyList<System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task!>!>! handlers, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+Mediarq.Core.Common.Requests.Notifications.INotification
+Mediarq.Core.Common.Requests.Notifications.INotificationHandler<TNotification>
+Mediarq.Core.Common.Requests.Notifications.INotificationHandler<TNotification>.Handle(TNotification notification, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Mediarq.Core.Common.Requests.Notifications.INotificationPublisher
+Mediarq.Core.Common.Requests.Notifications.INotificationPublisher.Publish(System.Collections.Generic.IReadOnlyList<System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task!>!>! handlers, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+Mediarq.Core.Common.Requests.Notifications.IOrderedNotificationHandler
+Mediarq.Core.Common.Requests.Notifications.IOrderedNotificationHandler.Order.get -> int
+Mediarq.Core.Common.Requests.Notifications.ParallelNotificationPublisher
+Mediarq.Core.Common.Requests.Notifications.ParallelNotificationPublisher.ParallelNotificationPublisher() -> void
+Mediarq.Core.Common.Requests.Notifications.ParallelNotificationPublisher.Publish(System.Collections.Generic.IReadOnlyList<System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task!>!>! handlers, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+Mediarq.Core.Common.Requests.Notifications.SequentialNotificationPublisher
+Mediarq.Core.Common.Requests.Notifications.SequentialNotificationPublisher.Publish(System.Collections.Generic.IReadOnlyList<System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task!>!>! handlers, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+Mediarq.Core.Common.Requests.Notifications.SequentialNotificationPublisher.SequentialNotificationPublisher() -> void
+Mediarq.Core.Common.Requests.Processors.IRequestPostProcessor<TRequest, TResponse>
+Mediarq.Core.Common.Requests.Processors.IRequestPostProcessor<TRequest, TResponse>.Process(TRequest request, TResponse response, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Mediarq.Core.Common.Requests.Processors.IRequestPreProcessor<TRequest>
+Mediarq.Core.Common.Requests.Processors.IRequestPreProcessor<TRequest>.Process(TRequest request, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Mediarq.Core.Common.Requests.Query.IQuery<TResponse>
+Mediarq.Core.Common.Requests.Query.IQueryHandler<TRequest, TResponse>
+Mediarq.Core.Common.Requests.Streaming.IStreamRequest<TResponse>
+Mediarq.Core.Common.Requests.Streaming.IStreamRequestHandler<TRequest, TResponse>
+Mediarq.Core.Common.Requests.Streaming.IStreamRequestHandler<TRequest, TResponse>.Handle(TRequest request, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<TResponse>!
+Mediarq.Core.Common.Requests.Validators.IValidationMessageResolver
+Mediarq.Core.Common.Requests.Validators.IValidationMessageResolver.Resolve(string! propertyName, string! message) -> string!
+Mediarq.Core.Common.Requests.Validators.IValidator<T>
+Mediarq.Core.Common.Requests.Validators.IValidator<T>.Validate(T instance) -> System.Collections.Generic.IEnumerable<Mediarq.Core.Common.Requests.Validators.ValidationResult!>!
+Mediarq.Core.Common.Requests.Validators.IValidator<T>.ValidateAsync(T instance, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Mediarq.Core.Common.Requests.Validators.ValidationResult!>!>!
+Mediarq.Core.Common.Requests.Validators.NotificationValidationException
+Mediarq.Core.Common.Requests.Validators.NotificationValidationException.Errors.get -> System.Collections.Generic.IReadOnlyList<Mediarq.Core.Common.Requests.Validators.ValidationPropertyError!>!
+Mediarq.Core.Common.Requests.Validators.NotificationValidationException.NotificationType.get -> System.Type!
+Mediarq.Core.Common.Requests.Validators.NotificationValidationException.NotificationValidationException(System.Type! notificationType, System.Collections.Generic.IReadOnlyList<Mediarq.Core.Common.Requests.Validators.ValidationPropertyError!>! errors) -> void
+Mediarq.Core.Common.Requests.Validators.ValidationPropertyError
+Mediarq.Core.Common.Requests.Validators.ValidationPropertyError.ErrorMessage.get -> string!
+Mediarq.Core.Common.Requests.Validators.ValidationPropertyError.ErrorMessage.init -> void
+Mediarq.Core.Common.Requests.Validators.ValidationPropertyError.PropertyName.get -> string!
+Mediarq.Core.Common.Requests.Validators.ValidationPropertyError.PropertyName.init -> void
+Mediarq.Core.Common.Requests.Validators.ValidationPropertyError.ValidationPropertyError(string! propertyName, string! errorMessage) -> void
+Mediarq.Core.Common.Requests.Validators.ValidationResult
+Mediarq.Core.Common.Requests.Validators.ValidationResult.Errors.get -> System.Collections.Generic.List<Mediarq.Core.Common.Requests.Validators.ValidationPropertyError!>!
+Mediarq.Core.Common.Requests.Validators.ValidationResult.IsValid.get -> bool
+Mediarq.Core.Common.Requests.Validators.ValidationResult.ValidationResult() -> void
+Mediarq.Core.Common.Requests.Validators.ValidationResult.ValidationResult(System.Collections.Generic.IEnumerable<Mediarq.Core.Common.Requests.Validators.ValidationPropertyError!>! errors) -> void
+Mediarq.Core.Common.Resolvers.HandlerResolver
+Mediarq.Core.Common.Resolvers.HandlerResolver.HandlerResolver(System.Func<System.Type!, object?>! resolver) -> void
+Mediarq.Core.Common.Resolvers.HandlerResolver.HandlerResolver(System.IServiceProvider! serviceProvider) -> void
+Mediarq.Core.Common.Resolvers.HandlerResolver.Resolve(System.Type! handlerType) -> object?
+Mediarq.Core.Common.Resolvers.HandlerResolver.Resolve<TService>() -> TService?
+Mediarq.Core.Common.Resolvers.HandlerResolver.ResolveAll(System.Type! handlerType) -> System.Collections.Generic.IEnumerable<object!>!
+Mediarq.Core.Common.Resolvers.HandlerResolver.ResolveAll<TService>() -> System.Collections.Generic.IReadOnlyList<TService>!
+Mediarq.Core.Common.Resolvers.IHandlerResolver
+Mediarq.Core.Common.Resolvers.IHandlerResolver.Resolve(System.Type! handlerType) -> object?
+Mediarq.Core.Common.Resolvers.IHandlerResolver.Resolve<TService>() -> TService?
+Mediarq.Core.Common.Resolvers.IHandlerResolver.ResolveAll(System.Type! handlerType) -> System.Collections.Generic.IEnumerable<object!>!
+Mediarq.Core.Common.Resolvers.IHandlerResolver.ResolveAll<TService>() -> System.Collections.Generic.IReadOnlyList<TService>!
+Mediarq.Core.Common.Resolvers.TypeResponseExtensions
+Mediarq.Core.Common.Results.ErrorType
+Mediarq.Core.Common.Results.ErrorType.Conflict = 4 -> Mediarq.Core.Common.Results.ErrorType
+Mediarq.Core.Common.Results.ErrorType.Failure = 0 -> Mediarq.Core.Common.Results.ErrorType
+Mediarq.Core.Common.Results.ErrorType.NotFound = 3 -> Mediarq.Core.Common.Results.ErrorType
+Mediarq.Core.Common.Results.ErrorType.Problem = 2 -> Mediarq.Core.Common.Results.ErrorType
+Mediarq.Core.Common.Results.ErrorType.Unauthorized = 5 -> Mediarq.Core.Common.Results.ErrorType
+Mediarq.Core.Common.Results.ErrorType.Validation = 1 -> Mediarq.Core.Common.Results.ErrorType
+Mediarq.Core.Common.Results.Result
+Mediarq.Core.Common.Results.Result.Error.get -> Mediarq.Core.Common.Results.ResultError!
+Mediarq.Core.Common.Results.Result.Error.init -> void
+Mediarq.Core.Common.Results.Result.IsFailure.get -> bool
+Mediarq.Core.Common.Results.Result.IsSuccess.get -> bool
+Mediarq.Core.Common.Results.Result.IsSuccess.init -> void
+Mediarq.Core.Common.Results.Result.Result(bool isSuccess, Mediarq.Core.Common.Results.ResultError! error) -> void
+Mediarq.Core.Common.Results.Result<TValue>
+Mediarq.Core.Common.Results.Result<TValue>.Result(TValue? value, bool isSuccess, Mediarq.Core.Common.Results.ResultError! error) -> void
+Mediarq.Core.Common.Results.Result<TValue>.Value.get -> TValue
+Mediarq.Core.Common.Results.ResultError
+Mediarq.Core.Common.Results.ResultError.Code.get -> string!
+Mediarq.Core.Common.Results.ResultError.Code.init -> void
+Mediarq.Core.Common.Results.ResultError.Message.get -> string!
+Mediarq.Core.Common.Results.ResultError.Message.init -> void
+Mediarq.Core.Common.Results.ResultError.ResultError(string! code, string! message, Mediarq.Core.Common.Results.ErrorType type) -> void
+Mediarq.Core.Common.Results.ResultError.Type.get -> Mediarq.Core.Common.Results.ErrorType
+Mediarq.Core.Common.Results.ResultError.Type.init -> void
+Mediarq.Core.Common.Results.ResultExtensions
+Mediarq.Core.Common.Results.ResultJsonConverterFactory
+Mediarq.Core.Common.Results.ResultJsonConverterFactory.ResultJsonConverterFactory() -> void
+Mediarq.Core.Common.Results.ValidationError
+Mediarq.Core.Common.Results.ValidationError.Errors.get -> Mediarq.Core.Common.Results.ResultError![]!
+Mediarq.Core.Common.Results.ValidationError.Errors.init -> void
+Mediarq.Core.Common.Results.ValidationError.ValidationError(Mediarq.Core.Common.Results.ResultError![]! errors) -> void
+Mediarq.Core.Common.Time.IClock
+Mediarq.Core.Common.Time.IClock.UtcNow.get -> System.DateTime
+Mediarq.Core.Common.Time.SystemClock
+Mediarq.Core.Common.Time.SystemClock.SystemClock() -> void
+Mediarq.Core.Common.Time.SystemClock.UtcNow.get -> System.DateTime
+Mediarq.Core.Common.User.DefaultUserContext
+Mediarq.Core.Common.User.DefaultUserContext.DefaultUserContext(string? userId = null, string! userName = "system", System.Collections.Generic.IEnumerable<string!>? roles = null) -> void
+Mediarq.Core.Common.User.DefaultUserContext.Roles.get -> System.Collections.Generic.IEnumerable<string!>!
+Mediarq.Core.Common.User.DefaultUserContext.Roles.init -> void
+Mediarq.Core.Common.User.DefaultUserContext.UserId.get -> string!
+Mediarq.Core.Common.User.DefaultUserContext.UserId.init -> void
+Mediarq.Core.Common.User.DefaultUserContext.UserName.get -> string!
+Mediarq.Core.Common.User.DefaultUserContext.UserName.init -> void
+Mediarq.Core.Common.User.HttpUserContext
+Mediarq.Core.Common.User.HttpUserContext.HttpUserContext(Microsoft.AspNetCore.Http.IHttpContextAccessor! httpContextAccessor) -> void
+Mediarq.Core.Common.User.HttpUserContext.Roles.get -> System.Collections.Generic.IEnumerable<string!>!
+Mediarq.Core.Common.User.HttpUserContext.UserId.get -> string?
+Mediarq.Core.Common.User.HttpUserContext.UserName.get -> string?
+Mediarq.Core.Common.User.IUserContext
+Mediarq.Core.Common.User.IUserContext.Roles.get -> System.Collections.Generic.IEnumerable<string!>!
+Mediarq.Core.Common.User.IUserContext.UserId.get -> string?
+Mediarq.Core.Common.User.IUserContext.UserName.get -> string?
+Mediarq.Core.Mediators.IMediator
+Mediarq.Core.Mediators.IPublisher
+Mediarq.Core.Mediators.IPublisher.Publish<TNotification>(TNotification notification, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Mediarq.Core.Mediators.ISender
+Mediarq.Core.Mediators.ISender.CreateStream<TResponse>(Mediarq.Core.Common.Requests.Streaming.IStreamRequest<TResponse>! request, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<TResponse>!
+Mediarq.Core.Mediators.ISender.Send(Mediarq.Core.Common.Requests.Command.ICommand! request, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Mediarq.Core.Mediators.ISender.Send<TResponse>(Mediarq.Core.Common.Requests.Abstraction.ICommandOrQuery<TResponse>! request, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<TResponse>!
+Mediarq.Core.Mediators.MediarqWrapperRegistry
+Mediarq.Core.Mediators.MediarqWrapperRegistry.Add<TRequest, TResponse>() -> Mediarq.Core.Mediators.MediarqWrapperRegistry!
+Mediarq.Core.Mediators.MediarqWrapperRegistry.AddNotification<TNotification>() -> Mediarq.Core.Mediators.MediarqWrapperRegistry!
+Mediarq.Core.Mediators.MediarqWrapperRegistry.AddStream<TRequest, TResponse>() -> Mediarq.Core.Mediators.MediarqWrapperRegistry!
+Mediarq.Core.Mediators.MediarqWrapperRegistry.MediarqWrapperRegistry() -> void
+Mediarq.Core.Mediators.Mediator
+Mediarq.Core.Mediators.Mediator.CreateStream<TResponse>(Mediarq.Core.Common.Requests.Streaming.IStreamRequest<TResponse>! request, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<TResponse>!
+Mediarq.Core.Mediators.Mediator.Mediator(Mediarq.Core.Common.Contexts.IRequestContextFactory! requestContextFactory, Mediarq.Core.Common.Resolvers.IHandlerResolver! handlerResolver, Mediarq.Core.Common.Requests.Notifications.INotificationPublisher! notificationPublisher, Mediarq.Core.Mediators.MediarqWrapperRegistry? wrapperRegistry = null, Mediarq.Core.Common.Pipeline.IStreamPipelineExecutor? streamPipelineExecutor = null) -> void
+Mediarq.Core.Mediators.Mediator.Publish<TNotification>(TNotification notification, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Mediarq.Core.Mediators.Mediator.Send(Mediarq.Core.Common.Requests.Command.ICommand! request, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Mediarq.Core.Mediators.Mediator.Send<TResponse>(Mediarq.Core.Common.Requests.Abstraction.ICommandOrQuery<TResponse>! request, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<TResponse>!
+Mediarq.Extensions.ServiceCollectionExtensions
+override Mediarq.Core.Common.Requests.Abstraction.Unit.Equals(object? obj) -> bool
+override Mediarq.Core.Common.Requests.Abstraction.Unit.GetHashCode() -> int
+override Mediarq.Core.Common.Requests.Abstraction.Unit.ToString() -> string!
+override Mediarq.Core.Common.Requests.Validators.ValidationPropertyError.ToString() -> string!
+override Mediarq.Core.Common.Results.ResultJsonConverterFactory.CanConvert(System.Type! typeToConvert) -> bool
+override Mediarq.Core.Common.Results.ResultJsonConverterFactory.CreateConverter(System.Type! typeToConvert, System.Text.Json.JsonSerializerOptions! options) -> System.Text.Json.Serialization.JsonConverter!
+static Mediarq.Core.Common.Pipeline.Behaviors.ValidationFailureRegistry.Register<TResponse>(System.Func<Mediarq.Core.Common.Results.ValidationError!, TResponse>! factory) -> void
+static Mediarq.Core.Common.Requests.Abstraction.Unit.Task.get -> System.Threading.Tasks.Task<Mediarq.Core.Common.Requests.Abstraction.Unit>!
+static Mediarq.Core.Common.Requests.Abstraction.Unit.operator !=(Mediarq.Core.Common.Requests.Abstraction.Unit left, Mediarq.Core.Common.Requests.Abstraction.Unit right) -> bool
+static Mediarq.Core.Common.Requests.Abstraction.Unit.operator ==(Mediarq.Core.Common.Requests.Abstraction.Unit left, Mediarq.Core.Common.Requests.Abstraction.Unit right) -> bool
+static Mediarq.Core.Common.Requests.Validators.ValidationResult.Failure(System.Collections.Generic.IEnumerable<Mediarq.Core.Common.Requests.Validators.ValidationPropertyError!>! errors) -> Mediarq.Core.Common.Requests.Validators.ValidationResult!
+static Mediarq.Core.Common.Requests.Validators.ValidationResult.Success() -> Mediarq.Core.Common.Requests.Validators.ValidationResult!
+static Mediarq.Core.Common.Resolvers.TypeResponseExtensions.GetResponseType(this object! request) -> System.Type!
+static Mediarq.Core.Common.Results.Result.Failure(Mediarq.Core.Common.Results.ResultError! error) -> Mediarq.Core.Common.Results.Result!
+static Mediarq.Core.Common.Results.Result.Failure<T>(Mediarq.Core.Common.Results.ResultError! error) -> Mediarq.Core.Common.Results.Result<T>!
+static Mediarq.Core.Common.Results.Result.Success() -> Mediarq.Core.Common.Results.Result!
+static Mediarq.Core.Common.Results.Result.Success<T>(T value) -> Mediarq.Core.Common.Results.Result<T>!
+static Mediarq.Core.Common.Results.Result.implicit operator Mediarq.Core.Common.Results.Result!(Mediarq.Core.Common.Results.ResultError! error) -> Mediarq.Core.Common.Results.Result!
+static Mediarq.Core.Common.Results.Result<TValue>.ValidationFailure(Mediarq.Core.Common.Results.ResultError! error) -> Mediarq.Core.Common.Results.Result<TValue>!
+static Mediarq.Core.Common.Results.Result<TValue>.implicit operator Mediarq.Core.Common.Results.Result<TValue>!(Mediarq.Core.Common.Results.ResultError! error) -> Mediarq.Core.Common.Results.Result<TValue>!
+static Mediarq.Core.Common.Results.Result<TValue>.implicit operator Mediarq.Core.Common.Results.Result<TValue>!(TValue value) -> Mediarq.Core.Common.Results.Result<TValue>!
+static Mediarq.Core.Common.Results.ResultError.Conflict(string! code, string! message) -> Mediarq.Core.Common.Results.ResultError!
+static Mediarq.Core.Common.Results.ResultError.Failure(string! code, string! message) -> Mediarq.Core.Common.Results.ResultError!
+static Mediarq.Core.Common.Results.ResultError.NotFound(string! code, string! message) -> Mediarq.Core.Common.Results.ResultError!
+static Mediarq.Core.Common.Results.ResultError.Problem(string! code, string! message) -> Mediarq.Core.Common.Results.ResultError!
+static Mediarq.Core.Common.Results.ResultExtensions.Bind<TIn, TOut>(this Mediarq.Core.Common.Results.Result<TIn>! result, System.Func<TIn, Mediarq.Core.Common.Results.Result<TOut>!>! bind) -> Mediarq.Core.Common.Results.Result<TOut>!
+static Mediarq.Core.Common.Results.ResultExtensions.BindAsync<TIn, TOut>(this Mediarq.Core.Common.Results.Result<TIn>! result, System.Func<TIn, System.Threading.Tasks.Task<Mediarq.Core.Common.Results.Result<TOut>!>!>! bind) -> System.Threading.Tasks.Task<Mediarq.Core.Common.Results.Result<TOut>!>!
+static Mediarq.Core.Common.Results.ResultExtensions.BindAsync<TIn, TOut>(this System.Threading.Tasks.Task<Mediarq.Core.Common.Results.Result<TIn>!>! resultTask, System.Func<TIn, System.Threading.Tasks.Task<Mediarq.Core.Common.Results.Result<TOut>!>!>! bind) -> System.Threading.Tasks.Task<Mediarq.Core.Common.Results.Result<TOut>!>!
+static Mediarq.Core.Common.Results.ResultExtensions.Combine(params Mediarq.Core.Common.Results.Result![]! results) -> Mediarq.Core.Common.Results.Result!
+static Mediarq.Core.Common.Results.ResultExtensions.Combine<T>(params Mediarq.Core.Common.Results.Result<T>![]! results) -> Mediarq.Core.Common.Results.Result<System.Collections.Generic.IReadOnlyList<T>!>!
+static Mediarq.Core.Common.Results.ResultExtensions.Ensure<T>(this Mediarq.Core.Common.Results.Result<T>! result, System.Func<T, bool>! predicate, Mediarq.Core.Common.Results.ResultError! error) -> Mediarq.Core.Common.Results.Result<T>!
+static Mediarq.Core.Common.Results.ResultExtensions.Map<TIn, TOut>(this Mediarq.Core.Common.Results.Result<TIn>! result, System.Func<TIn, TOut>! map) -> Mediarq.Core.Common.Results.Result<TOut>!
+static Mediarq.Core.Common.Results.ResultExtensions.MapAsync<TIn, TOut>(this Mediarq.Core.Common.Results.Result<TIn>! result, System.Func<TIn, System.Threading.Tasks.Task<TOut>!>! map) -> System.Threading.Tasks.Task<Mediarq.Core.Common.Results.Result<TOut>!>!
+static Mediarq.Core.Common.Results.ResultExtensions.MapAsync<TIn, TOut>(this System.Threading.Tasks.Task<Mediarq.Core.Common.Results.Result<TIn>!>! resultTask, System.Func<TIn, TOut>! map) -> System.Threading.Tasks.Task<Mediarq.Core.Common.Results.Result<TOut>!>!
+static Mediarq.Core.Common.Results.ResultExtensions.Match<TIn, TOut>(this Mediarq.Core.Common.Results.Result<TIn>! result, System.Func<TIn, TOut>! onSuccess, System.Func<Mediarq.Core.Common.Results.ResultError!, TOut>! onFailure) -> TOut
+static Mediarq.Core.Common.Results.ResultExtensions.Match<TOut>(this Mediarq.Core.Common.Results.Result! result, System.Func<TOut>! onSuccess, System.Func<Mediarq.Core.Common.Results.ResultError!, TOut>! onFailure) -> TOut
+static Mediarq.Core.Common.Results.ResultExtensions.MatchAsync<TIn, TOut>(this System.Threading.Tasks.Task<Mediarq.Core.Common.Results.Result<TIn>!>! resultTask, System.Func<TIn, TOut>! onSuccess, System.Func<Mediarq.Core.Common.Results.ResultError!, TOut>! onFailure) -> System.Threading.Tasks.Task<TOut>!
+static Mediarq.Core.Common.Results.ResultExtensions.OrElse<T>(this Mediarq.Core.Common.Results.Result<T>! result, System.Func<Mediarq.Core.Common.Results.ResultError!, Mediarq.Core.Common.Results.Result<T>!>! alternative) -> Mediarq.Core.Common.Results.Result<T>!
+static Mediarq.Core.Common.Results.ResultExtensions.Recover<T>(this Mediarq.Core.Common.Results.Result<T>! result, System.Func<Mediarq.Core.Common.Results.ResultError!, T>! fallback) -> Mediarq.Core.Common.Results.Result<T>!
+static Mediarq.Core.Common.Results.ResultExtensions.Tap<T>(this Mediarq.Core.Common.Results.Result<T>! result, System.Action<T>! action) -> Mediarq.Core.Common.Results.Result<T>!
+static Mediarq.Core.Common.Results.ResultExtensions.TapAsync<T>(this System.Threading.Tasks.Task<Mediarq.Core.Common.Results.Result<T>!>! resultTask, System.Action<T>! action) -> System.Threading.Tasks.Task<Mediarq.Core.Common.Results.Result<T>!>!
+static Mediarq.Core.Common.Results.ResultExtensions.ToResult<T>(this T? value, Mediarq.Core.Common.Results.ResultError! error) -> Mediarq.Core.Common.Results.Result<T!>!
+static Mediarq.Core.Common.Results.ResultExtensions.Try<T>(System.Func<T>! operation, System.Func<System.Exception!, Mediarq.Core.Common.Results.ResultError!>! onError) -> Mediarq.Core.Common.Results.Result<T>!
+static Mediarq.Core.Common.Results.ResultExtensions.TryAsync<T>(System.Func<System.Threading.Tasks.Task<T>!>! operation, System.Func<System.Exception!, Mediarq.Core.Common.Results.ResultError!>! onError) -> System.Threading.Tasks.Task<Mediarq.Core.Common.Results.Result<T>!>!
+static Mediarq.Core.Common.Results.ResultExtensions.TryGetValue<T>(this Mediarq.Core.Common.Results.Result<T>! result, out T value) -> bool
+static Mediarq.Core.Common.Results.ValidationError.FromResults(System.Collections.Generic.IEnumerable<Mediarq.Core.Common.Results.Result!>! results) -> Mediarq.Core.Common.Results.ValidationError!
+static Mediarq.Extensions.ServiceCollectionExtensions.AddMediarq(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, bool isHttp = false, params System.Reflection.Assembly![]! assemblies) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static Mediarq.Extensions.ServiceCollectionExtensions.AddMediarqCore(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, bool isHttp = false) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static Mediarq.Extensions.ServiceCollectionExtensions.AddMediarqPerformanceTracking(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static Mediarq.Extensions.ServiceCollectionExtensions.AddMediarqRequestLogging(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static Mediarq.Extensions.ServiceCollectionExtensions.AddMediarqTimeout(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static readonly Mediarq.Core.Common.Requests.Abstraction.Unit.Value -> Mediarq.Core.Common.Requests.Abstraction.Unit
+static readonly Mediarq.Core.Common.Results.ResultError.None -> Mediarq.Core.Common.Results.ResultError!
+static readonly Mediarq.Core.Common.Results.ResultError.NullValue -> Mediarq.Core.Common.Results.ResultError!

--- a/src/Mediarq.Core/PublicAPI.Unshipped.txt
+++ b/src/Mediarq.Core/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Mediarq.DataAnnotations/PublicAPI.Shipped.txt
+++ b/src/Mediarq.DataAnnotations/PublicAPI.Shipped.txt
@@ -1,0 +1,6 @@
+#nullable enable
+Mediarq.DataAnnotations.DataAnnotationsServiceCollectionExtensions
+Mediarq.DataAnnotations.DataAnnotationsValidator<T>
+Mediarq.DataAnnotations.DataAnnotationsValidator<T>.DataAnnotationsValidator() -> void
+Mediarq.DataAnnotations.DataAnnotationsValidator<T>.Validate(T instance) -> System.Collections.Generic.IEnumerable<Mediarq.Core.Common.Requests.Validators.ValidationResult!>!
+static Mediarq.DataAnnotations.DataAnnotationsServiceCollectionExtensions.AddMediarqDataAnnotations(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!

--- a/src/Mediarq.DataAnnotations/PublicAPI.Unshipped.txt
+++ b/src/Mediarq.DataAnnotations/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Mediarq.Diagnostics/PublicAPI.Shipped.txt
+++ b/src/Mediarq.Diagnostics/PublicAPI.Shipped.txt
@@ -1,0 +1,17 @@
+#nullable enable
+Mediarq.Diagnostics.DiagnosticsBehavior<TRequest, TResponse>
+Mediarq.Diagnostics.DiagnosticsBehavior<TRequest, TResponse>.DiagnosticsBehavior() -> void
+Mediarq.Diagnostics.DiagnosticsBehavior<TRequest, TResponse>.Handle(Mediarq.Core.Common.Contexts.IMutableRequestContext<TRequest, TResponse>! context, System.Func<System.Threading.Tasks.Task<TResponse>!>! handle, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<TResponse>!
+Mediarq.Diagnostics.DiagnosticsBehavior<TRequest, TResponse>.Order.get -> int
+Mediarq.Diagnostics.DiagnosticsNotificationPublisher
+Mediarq.Diagnostics.DiagnosticsNotificationPublisher.DiagnosticsNotificationPublisher(Mediarq.Core.Common.Requests.Notifications.INotificationPublisher! inner) -> void
+Mediarq.Diagnostics.DiagnosticsNotificationPublisher.Publish(System.Collections.Generic.IReadOnlyList<System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task!>!>! handlers, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+Mediarq.Diagnostics.DiagnosticsServiceCollectionExtensions
+Mediarq.Diagnostics.MediarqDiagnostics
+Mediarq.Diagnostics.StreamDiagnosticsBehavior<TRequest, TResponse>
+Mediarq.Diagnostics.StreamDiagnosticsBehavior<TRequest, TResponse>.Handle(TRequest request, System.Func<System.Collections.Generic.IAsyncEnumerable<TResponse>!>! continuation, System.Threading.CancellationToken cancellationToken) -> System.Collections.Generic.IAsyncEnumerable<TResponse>!
+Mediarq.Diagnostics.StreamDiagnosticsBehavior<TRequest, TResponse>.Order.get -> int
+Mediarq.Diagnostics.StreamDiagnosticsBehavior<TRequest, TResponse>.StreamDiagnosticsBehavior() -> void
+const Mediarq.Diagnostics.MediarqDiagnostics.SourceName = "Mediarq" -> string!
+static Mediarq.Diagnostics.DiagnosticsServiceCollectionExtensions.AddMediarqDiagnostics(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static readonly Mediarq.Diagnostics.MediarqDiagnostics.ActivitySource -> System.Diagnostics.ActivitySource!

--- a/src/Mediarq.Diagnostics/PublicAPI.Unshipped.txt
+++ b/src/Mediarq.Diagnostics/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Mediarq.EntityFrameworkCore/PublicAPI.Shipped.txt
+++ b/src/Mediarq.EntityFrameworkCore/PublicAPI.Shipped.txt
@@ -1,0 +1,6 @@
+#nullable enable
+Mediarq.EntityFrameworkCore.EfCoreUnitOfWork<TContext>
+Mediarq.EntityFrameworkCore.EfCoreUnitOfWork<TContext>.EfCoreUnitOfWork(TContext! context) -> void
+Mediarq.EntityFrameworkCore.EfCoreUnitOfWork<TContext>.SaveChangesAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<int>!
+Mediarq.EntityFrameworkCore.EntityFrameworkCoreServiceCollectionExtensions
+static Mediarq.EntityFrameworkCore.EntityFrameworkCoreServiceCollectionExtensions.AddMediarqEntityFrameworkCore<TContext>(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!

--- a/src/Mediarq.EntityFrameworkCore/PublicAPI.Unshipped.txt
+++ b/src/Mediarq.EntityFrameworkCore/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Mediarq.FluentValidation/PublicAPI.Shipped.txt
+++ b/src/Mediarq.FluentValidation/PublicAPI.Shipped.txt
@@ -1,0 +1,7 @@
+#nullable enable
+Mediarq.FluentValidation.FluentValidationServiceCollectionExtensions
+Mediarq.FluentValidation.FluentValidationValidator<T>
+Mediarq.FluentValidation.FluentValidationValidator<T>.FluentValidationValidator(System.Collections.Generic.IEnumerable<FluentValidation.IValidator<T>!>! validators) -> void
+Mediarq.FluentValidation.FluentValidationValidator<T>.Validate(T instance) -> System.Collections.Generic.IEnumerable<Mediarq.Core.Common.Requests.Validators.ValidationResult!>!
+Mediarq.FluentValidation.FluentValidationValidator<T>.ValidateAsync(T instance, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<Mediarq.Core.Common.Requests.Validators.ValidationResult!>!>!
+static Mediarq.FluentValidation.FluentValidationServiceCollectionExtensions.AddMediarqFluentValidation(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!

--- a/src/Mediarq.FluentValidation/PublicAPI.Unshipped.txt
+++ b/src/Mediarq.FluentValidation/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Mediarq.Idempotency/PublicAPI.Shipped.txt
+++ b/src/Mediarq.Idempotency/PublicAPI.Shipped.txt
@@ -1,0 +1,10 @@
+#nullable enable
+Mediarq.Idempotency.IIdempotentRequest
+Mediarq.Idempotency.IIdempotentRequest.IdempotencyDuration.get -> System.TimeSpan?
+Mediarq.Idempotency.IIdempotentRequest.IdempotencyKey.get -> string!
+Mediarq.Idempotency.IdempotencyBehavior<TRequest, TResponse>
+Mediarq.Idempotency.IdempotencyBehavior<TRequest, TResponse>.Handle(Mediarq.Core.Common.Contexts.IMutableRequestContext<TRequest, TResponse>! context, System.Func<System.Threading.Tasks.Task<TResponse>!>! handle, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<TResponse>!
+Mediarq.Idempotency.IdempotencyBehavior<TRequest, TResponse>.IdempotencyBehavior(Microsoft.Extensions.Caching.Distributed.IDistributedCache! cache, Mediarq.Caching.IMediarqCacheSerializer! serializer) -> void
+Mediarq.Idempotency.IdempotencyBehavior<TRequest, TResponse>.IsActive.get -> bool
+Mediarq.Idempotency.IdempotencyServiceCollectionExtensions
+static Mediarq.Idempotency.IdempotencyServiceCollectionExtensions.AddMediarqIdempotency(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!

--- a/src/Mediarq.Idempotency/PublicAPI.Unshipped.txt
+++ b/src/Mediarq.Idempotency/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Mediarq.MassTransit/PublicAPI.Shipped.txt
+++ b/src/Mediarq.MassTransit/PublicAPI.Shipped.txt
@@ -1,0 +1,8 @@
+#nullable enable
+Mediarq.MassTransit.IIntegrationEvent
+Mediarq.MassTransit.MassTransitNotificationForwarder<TNotification>
+Mediarq.MassTransit.MassTransitNotificationForwarder<TNotification>.Handle(TNotification! notification, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Mediarq.MassTransit.MassTransitNotificationForwarder<TNotification>.MassTransitNotificationForwarder(MassTransit.IPublishEndpoint! publishEndpoint) -> void
+Mediarq.MassTransit.MassTransitServiceCollectionExtensions
+static Mediarq.MassTransit.MassTransitServiceCollectionExtensions.AddMediarqMassTransitForwarding(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, params System.Reflection.Assembly![]! assemblies) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static Mediarq.MassTransit.MassTransitServiceCollectionExtensions.AddMediarqMassTransitForwarding<TNotification>(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!

--- a/src/Mediarq.MassTransit/PublicAPI.Unshipped.txt
+++ b/src/Mediarq.MassTransit/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Mediarq.OpenTelemetry/PublicAPI.Shipped.txt
+++ b/src/Mediarq.OpenTelemetry/PublicAPI.Shipped.txt
@@ -1,0 +1,4 @@
+#nullable enable
+Mediarq.OpenTelemetry.MediarqInstrumentationExtensions
+static Mediarq.OpenTelemetry.MediarqInstrumentationExtensions.AddMediarqInstrumentation(this OpenTelemetry.Metrics.MeterProviderBuilder! builder) -> OpenTelemetry.Metrics.MeterProviderBuilder!
+static Mediarq.OpenTelemetry.MediarqInstrumentationExtensions.AddMediarqInstrumentation(this OpenTelemetry.Trace.TracerProviderBuilder! builder) -> OpenTelemetry.Trace.TracerProviderBuilder!

--- a/src/Mediarq.OpenTelemetry/PublicAPI.Unshipped.txt
+++ b/src/Mediarq.OpenTelemetry/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Mediarq.Outbox/PublicAPI.Shipped.txt
+++ b/src/Mediarq.Outbox/PublicAPI.Shipped.txt
@@ -1,0 +1,34 @@
+#nullable enable
+Mediarq.Outbox.EfCoreOutbox<TContext>
+Mediarq.Outbox.EfCoreOutbox<TContext>.EfCoreOutbox(TContext! context) -> void
+Mediarq.Outbox.EfCoreOutbox<TContext>.Enqueue<TNotification>(TNotification notification) -> void
+Mediarq.Outbox.IOutbox
+Mediarq.Outbox.IOutbox.Enqueue<TNotification>(TNotification notification) -> void
+Mediarq.Outbox.OutboxMessage
+Mediarq.Outbox.OutboxMessage.Attempts.get -> int
+Mediarq.Outbox.OutboxMessage.Attempts.set -> void
+Mediarq.Outbox.OutboxMessage.Error.get -> string?
+Mediarq.Outbox.OutboxMessage.Error.set -> void
+Mediarq.Outbox.OutboxMessage.Id.get -> System.Guid
+Mediarq.Outbox.OutboxMessage.Id.set -> void
+Mediarq.Outbox.OutboxMessage.OccurredOnUtc.get -> System.DateTime
+Mediarq.Outbox.OutboxMessage.OccurredOnUtc.set -> void
+Mediarq.Outbox.OutboxMessage.OutboxMessage() -> void
+Mediarq.Outbox.OutboxMessage.Payload.get -> string!
+Mediarq.Outbox.OutboxMessage.Payload.set -> void
+Mediarq.Outbox.OutboxMessage.ProcessedOnUtc.get -> System.DateTime?
+Mediarq.Outbox.OutboxMessage.ProcessedOnUtc.set -> void
+Mediarq.Outbox.OutboxMessage.Type.get -> string!
+Mediarq.Outbox.OutboxMessage.Type.set -> void
+Mediarq.Outbox.OutboxModelBuilderExtensions
+Mediarq.Outbox.OutboxOptions
+Mediarq.Outbox.OutboxOptions.BatchSize.get -> int
+Mediarq.Outbox.OutboxOptions.BatchSize.set -> void
+Mediarq.Outbox.OutboxOptions.OutboxOptions() -> void
+Mediarq.Outbox.OutboxOptions.PollingInterval.get -> System.TimeSpan
+Mediarq.Outbox.OutboxOptions.PollingInterval.set -> void
+Mediarq.Outbox.OutboxProcessor<TContext>
+Mediarq.Outbox.OutboxProcessor<TContext>.OutboxProcessor(Microsoft.Extensions.DependencyInjection.IServiceScopeFactory! scopeFactory, Mediarq.Outbox.OutboxOptions! options, Microsoft.Extensions.Logging.ILogger<Mediarq.Outbox.OutboxProcessor<TContext!>!>? logger = null) -> void
+Mediarq.Outbox.OutboxServiceCollectionExtensions
+static Mediarq.Outbox.OutboxModelBuilderExtensions.ApplyMediarqOutbox(this Microsoft.EntityFrameworkCore.ModelBuilder! modelBuilder) -> Microsoft.EntityFrameworkCore.ModelBuilder!
+static Mediarq.Outbox.OutboxServiceCollectionExtensions.AddMediarqOutbox<TContext>(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, System.Action<Mediarq.Outbox.OutboxOptions!>? configure = null) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!

--- a/src/Mediarq.Outbox/PublicAPI.Unshipped.txt
+++ b/src/Mediarq.Outbox/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Mediarq.Polly/PublicAPI.Shipped.txt
+++ b/src/Mediarq.Polly/PublicAPI.Shipped.txt
@@ -1,0 +1,8 @@
+#nullable enable
+Mediarq.Polly.IResilientRequest
+Mediarq.Polly.IResilientRequest.ResiliencePipelineName.get -> string!
+Mediarq.Polly.ResilienceBehavior<TRequest, TResponse>
+Mediarq.Polly.ResilienceBehavior<TRequest, TResponse>.Handle(Mediarq.Core.Common.Contexts.IMutableRequestContext<TRequest, TResponse>! context, System.Func<System.Threading.Tasks.Task<TResponse>!>! handle, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<TResponse>!
+Mediarq.Polly.ResilienceBehavior<TRequest, TResponse>.ResilienceBehavior(Polly.Registry.ResiliencePipelineProvider<string!>! pipelineProvider) -> void
+Mediarq.Polly.ResilienceServiceCollectionExtensions
+static Mediarq.Polly.ResilienceServiceCollectionExtensions.AddMediarqResilience(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!

--- a/src/Mediarq.Polly/PublicAPI.Unshipped.txt
+++ b/src/Mediarq.Polly/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Mediarq.SourceGenerators/PublicAPI.Shipped.txt
+++ b/src/Mediarq.SourceGenerators/PublicAPI.Shipped.txt
@@ -1,0 +1,4 @@
+#nullable enable
+Mediarq.SourceGenerators.MediarqRegistrationGenerator
+Mediarq.SourceGenerators.MediarqRegistrationGenerator.Initialize(Microsoft.CodeAnalysis.IncrementalGeneratorInitializationContext context) -> void
+Mediarq.SourceGenerators.MediarqRegistrationGenerator.MediarqRegistrationGenerator() -> void

--- a/src/Mediarq.SourceGenerators/PublicAPI.Unshipped.txt
+++ b/src/Mediarq.SourceGenerators/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Mediarq.UnitOfWork/PublicAPI.Shipped.txt
+++ b/src/Mediarq.UnitOfWork/PublicAPI.Shipped.txt
@@ -1,0 +1,10 @@
+#nullable enable
+Mediarq.UnitOfWork.ITransactionalRequest
+Mediarq.UnitOfWork.IUnitOfWork
+Mediarq.UnitOfWork.IUnitOfWork.SaveChangesAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<int>!
+Mediarq.UnitOfWork.UnitOfWorkBehavior<TRequest, TResponse>
+Mediarq.UnitOfWork.UnitOfWorkBehavior<TRequest, TResponse>.Handle(Mediarq.Core.Common.Contexts.IMutableRequestContext<TRequest, TResponse>! context, System.Func<System.Threading.Tasks.Task<TResponse>!>! handle, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<TResponse>!
+Mediarq.UnitOfWork.UnitOfWorkBehavior<TRequest, TResponse>.UnitOfWorkBehavior(Mediarq.UnitOfWork.IUnitOfWork! unitOfWork) -> void
+Mediarq.UnitOfWork.UnitOfWorkServiceCollectionExtensions
+static Mediarq.UnitOfWork.UnitOfWorkServiceCollectionExtensions.AddMediarqUnitOfWork(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static Mediarq.UnitOfWork.UnitOfWorkServiceCollectionExtensions.AddMediarqUnitOfWork<TUnitOfWork>(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!

--- a/src/Mediarq.UnitOfWork/PublicAPI.Unshipped.txt
+++ b/src/Mediarq.UnitOfWork/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Mediarq/PublicAPI.Shipped.txt
+++ b/src/Mediarq/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Mediarq/PublicAPI.Unshipped.txt
+++ b/src/Mediarq/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable


### PR DESCRIPTION
## Summary
- Every package under `src/` now references `Microsoft.CodeAnalysis.PublicApiAnalyzers`, wired once for all of them via `src/Directory.Build.props` (no per-project edits needed).
- Each package gets a `PublicAPI.Shipped.txt` seeded with its current (already-released `v1.0.0`) public surface, and an empty `PublicAPI.Unshipped.txt`. Going forward, adding/removing/renaming public API surfaces as an IDE/build warning (`RS0016`/`RS0017`) instead of drifting silently — matches the "public API frozen since v1.0.0" rule in `docs/BRANCHING.md`. Runs as a warning only (visible in the IDE and CI logs), does not fail the build — this is a deliberate-change prompt, not a hard gate.
- Adds `docs/guides/versioning.md`: SemVer rules (MAJOR/MINOR/PATCH) + the day-to-day `PublicAPI.*.txt` workflow (add/remove/release), linked from `docs/index.md` and `docs/toc.yml`.
- Closes #92.

## Test plan
- [x] `dotnet build Mediarq.sln` — 0 warnings, 0 errors (confirms the seeded `PublicAPI.Shipped.txt` files match every package's actual current public surface across net8/9/10)
- [x] `dotnet test Mediarq.sln` — all suites green, no behavior touched (analyzer-only change)