### PR TITLE
feat(analyzers): add captive-dependency analyzer (MQ200)

### DIFF
--- a/Tests/Mediarq.Analyzers.Tests/CaptiveDependencyAnalyzerTests.cs
+++ b/Tests/Mediarq.Analyzers.Tests/CaptiveDependencyAnalyzerTests.cs
@@ -1,0 +1,148 @@
+using Mediarq.Analyzers;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+
+namespace Mediarq.Analyzers.Tests;
+
+public class CaptiveDependencyAnalyzerTests
+{
+    // Minimal stubs for the types the analyzer looks for by name/namespace: the real
+    // RegisterHandlerAttribute (over the real ServiceLifetime enum) and a fake DbContext.
+    private const string Stubs = @"
+namespace Mediarq.Core.Common.Registration
+{
+    [System.AttributeUsage(System.AttributeTargets.Class)]
+    public sealed class RegisterHandlerAttribute : System.Attribute
+    {
+        public RegisterHandlerAttribute(Microsoft.Extensions.DependencyInjection.ServiceLifetime lifetime = Microsoft.Extensions.DependencyInjection.ServiceLifetime.Scoped) { }
+    }
+}
+
+namespace Microsoft.EntityFrameworkCore
+{
+    public class DbContext { }
+}
+";
+
+    private static async Task VerifyAsync(string source, params DiagnosticResult[] expected)
+    {
+        var test = new CSharpAnalyzerTest<CaptiveDependencyAnalyzer, DefaultVerifier>
+        {
+            TestCode = source + Stubs,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+            CompilerDiagnostics = CompilerDiagnostics.None,
+        };
+        test.TestState.AdditionalReferences.Add(typeof(Microsoft.Extensions.DependencyInjection.ServiceLifetime).Assembly);
+        test.ExpectedDiagnostics.AddRange(expected);
+        await test.RunAsync();
+    }
+
+    private static DiagnosticResult Diagnostic(int markupKey)
+        => new DiagnosticResult(CaptiveDependencyAnalyzer.DiagnosticId, DiagnosticSeverity.Warning).WithLocation(markupKey);
+
+    [Fact]
+    public async Task Flags_Singleton_Depending_On_DbContext()
+    {
+        const string source = @"
+using Mediarq.Core.Common.Registration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.EntityFrameworkCore;
+
+[RegisterHandler(ServiceLifetime.Singleton)]
+public class MyBehavior
+{
+    public MyBehavior(DbContext {|#0:db|}) { }
+}
+";
+        await VerifyAsync(source, Diagnostic(0).WithArguments("MyBehavior", "DbContext", "which is a DbContext (scoped by convention)"));
+    }
+
+    [Fact]
+    public async Task Flags_Singleton_Depending_On_Explicit_Scoped()
+    {
+        const string source = @"
+using Mediarq.Core.Common.Registration;
+using Microsoft.Extensions.DependencyInjection;
+
+[RegisterHandler(ServiceLifetime.Scoped)]
+public class Dependency { }
+
+[RegisterHandler(ServiceLifetime.Singleton)]
+public class MyBehavior
+{
+    public MyBehavior(Dependency {|#0:dependency|}) { }
+}
+";
+        await VerifyAsync(source, Diagnostic(0).WithArguments("MyBehavior", "Dependency", "registered as Scoped"));
+    }
+
+    [Fact]
+    public async Task Flags_Singleton_Depending_On_Explicit_Transient()
+    {
+        const string source = @"
+using Mediarq.Core.Common.Registration;
+using Microsoft.Extensions.DependencyInjection;
+
+[RegisterHandler(ServiceLifetime.Transient)]
+public class Dependency { }
+
+[RegisterHandler(ServiceLifetime.Singleton)]
+public class MyBehavior
+{
+    public MyBehavior(Dependency {|#0:dependency|}) { }
+}
+";
+        await VerifyAsync(source, Diagnostic(0).WithArguments("MyBehavior", "Dependency", "registered as Transient"));
+    }
+
+    [Fact]
+    public Task Does_Not_Flag_Singleton_Depending_On_Another_Singleton()
+        => VerifyAsync(@"
+using Mediarq.Core.Common.Registration;
+using Microsoft.Extensions.DependencyInjection;
+
+[RegisterHandler(ServiceLifetime.Singleton)]
+public class Dependency { }
+
+[RegisterHandler(ServiceLifetime.Singleton)]
+public class MyBehavior
+{
+    public MyBehavior(Dependency dependency) { }
+}
+");
+
+    [Fact]
+    public Task Does_Not_Flag_Singleton_Depending_On_An_Undecorated_Type()
+        => VerifyAsync(@"
+using Mediarq.Core.Common.Registration;
+using Microsoft.Extensions.DependencyInjection;
+
+// No [RegisterHandler]: default Scoped, but not an explicit signal we compare against.
+public class Dependency { }
+
+[RegisterHandler(ServiceLifetime.Singleton)]
+public class MyBehavior
+{
+    public MyBehavior(Dependency dependency) { }
+}
+");
+
+    [Fact]
+    public Task Does_Not_Flag_A_Scoped_Type_Depending_On_DbContext()
+        => VerifyAsync(@"
+using Mediarq.Core.Common.Registration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.EntityFrameworkCore;
+
+[RegisterHandler(ServiceLifetime.Scoped)]
+public class MyBehavior
+{
+    public MyBehavior(DbContext db) { }
+}
+");
+
+    [Fact]
+    public Task Does_Not_Flag_Plain_Code()
+        => VerifyAsync("public class Plain { public Plain(object dependency) { } }");
+}

--- a/Tests/Mediarq.Analyzers.Tests/Mediarq.Analyzers.Tests.csproj
+++ b/Tests/Mediarq.Analyzers.Tests/Mediarq.Analyzers.Tests.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="1.1.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -25,6 +25,26 @@ generator doesn't see). Add the handler, or ignore if intentional.
 Your `IValidator<T>` is for a `T` that is never dispatched, so it can never run. Point it at a request
 or notification type.
 
+## Lifetime
+
+### Build warning `MQ200` — Singleton depends on a shorter-lived type
+A handler, behavior or validator marked `[RegisterHandler(ServiceLifetime.Singleton)]` constructor-injects
+a `DbContext`, or another Mediarq type explicitly marked `Scoped`/`Transient`. That dependency is resolved
+**once** and captured for the app's whole lifetime instead of once per scope/request — the classic
+*captive dependency* bug (a `DbContext` shared and mutated concurrently across requests, or stale data
+from a scoped service that should have been refreshed).
+
+Fix by either:
+- Lowering the Singleton's lifetime to `Scoped` (the default — just remove the attribute, or pass
+  `ServiceLifetime.Scoped`), if it doesn't actually need to be a Singleton; or
+- Injecting `IServiceScopeFactory` / `IServiceProvider` instead and resolving the scoped dependency inside
+  a short-lived scope created per use, instead of depending on it directly.
+
+This analyzer only compares **explicit** lifetimes (`[RegisterHandler(...)]` on both sides, or a
+`DbContext`-derived parameter type) — it has no visibility into a consumer's arbitrary
+`services.AddScoped<T>()` calls outside the Mediarq registration model, so it stays silent rather than
+guess and risk a false positive.
+
 ## Validation
 
 ### My validation never runs (no error, the handler just runs)

--- a/src/Mediarq.Analyzers/CaptiveDependencyAnalyzer.cs
+++ b/src/Mediarq.Analyzers/CaptiveDependencyAnalyzer.cs
@@ -1,0 +1,152 @@
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Mediarq.Analyzers;
+
+/// <summary>
+/// Reports a Mediarq handler/behavior/validator explicitly registered as
+/// <c>ServiceLifetime.Singleton</c> (via <c>[RegisterHandler(ServiceLifetime.Singleton)]</c>) whose
+/// constructor depends on a shorter-lived type — a <c>DbContext</c>, or another Mediarq type explicitly
+/// registered as <c>Scoped</c>/<c>Transient</c>. The dependency instance would be resolved once and
+/// captured for the lifetime of the app instead of per scope/request: the classic "captive dependency"
+/// bug (stale data, a disposed/thread-unsafe <c>DbContext</c> shared across requests, ...).
+/// </summary>
+/// <remarks>
+/// Only types with an <em>explicit</em> lifetime marker are compared, on both sides: this analyzer has
+/// no visibility into a consumer's arbitrary <c>services.AddScoped&lt;T&gt;()</c> calls outside the
+/// Mediarq registration model, so it stays silent rather than guess and risk false positives.
+/// </remarks>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class CaptiveDependencyAnalyzer : DiagnosticAnalyzer
+{
+    /// <summary>The diagnostic id reported for a captive-dependency risk.</summary>
+    public const string DiagnosticId = "MQ200";
+
+    private const string RegisterHandlerAttributeName = "RegisterHandlerAttribute";
+    private const string RegisterHandlerNamespace = "Mediarq.Core.Common.Registration";
+    private const string DbContextTypeName = "DbContext";
+    private const string DbContextNamespace = "Microsoft.EntityFrameworkCore";
+
+    private static readonly DiagnosticDescriptor Rule = new(
+        id: DiagnosticId,
+        title: "Singleton depends on a shorter-lived type (captive dependency)",
+        messageFormat: "'{0}' is registered as Singleton but its constructor depends on '{1}', {2} — the instance would be captured for the app's lifetime instead of per scope",
+        category: "Mediarq.Lifetime",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "A Singleton-lifetime Mediarq handler, behavior or validator that constructor-injects a Scoped or Transient dependency (or a DbContext) captures it for the lifetime of the app instead of resolving a fresh instance per scope — usually a bug.",
+        helpLinkUri: "https://github.com/rouffou/mediarq/blob/main/docs/guides/troubleshooting.md#lifetime");
+
+    /// <inheritdoc />
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+    /// <inheritdoc />
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSymbolAction(AnalyzeType, SymbolKind.NamedType);
+    }
+
+    private static void AnalyzeType(SymbolAnalysisContext context)
+    {
+        var type = (INamedTypeSymbol)context.Symbol;
+        if (type.TypeKind != TypeKind.Class || type.IsAbstract)
+        {
+            return;
+        }
+
+        if (!TryGetExplicitLifetime(type, out var lifetime) || lifetime != Lifetime.Singleton)
+        {
+            return;
+        }
+
+        foreach (var ctor in type.InstanceConstructors)
+        {
+            if (ctor.DeclaredAccessibility != Accessibility.Public)
+            {
+                continue;
+            }
+
+            foreach (var parameter in ctor.Parameters)
+            {
+                if (parameter.Type is not INamedTypeSymbol parameterType)
+                {
+                    continue;
+                }
+
+                if (IsDbContext(parameterType))
+                {
+                    Report(context, type, parameter, "which is a DbContext (scoped by convention)");
+                    continue;
+                }
+
+                if (TryGetExplicitLifetime(parameterType, out var dependencyLifetime) && dependencyLifetime != Lifetime.Singleton)
+                {
+                    Report(context, type, parameter, "registered as " + dependencyLifetime);
+                }
+            }
+        }
+    }
+
+    private static void Report(SymbolAnalysisContext context, INamedTypeSymbol type, IParameterSymbol parameter, string reason)
+    {
+        var location = parameter.Locations.FirstOrDefault() ?? type.Locations.FirstOrDefault() ?? Location.None;
+        context.ReportDiagnostic(Diagnostic.Create(Rule, location, type.Name, parameter.Type.Name, reason));
+    }
+
+    private static bool IsDbContext(INamedTypeSymbol type)
+    {
+        for (var current = type; current is not null; current = current.BaseType)
+        {
+            if (current.Name == DbContextTypeName && current.ContainingNamespace?.ToDisplayString() == DbContextNamespace)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    // Reads [RegisterHandler(ServiceLifetime)]; returns false when the attribute is absent (default
+    // Scoped, but not an *explicit* signal we can safely compare against).
+    private static bool TryGetExplicitLifetime(INamedTypeSymbol type, out string lifetime)
+    {
+        foreach (var attribute in type.GetAttributes())
+        {
+            var attributeClass = attribute.AttributeClass;
+            if (attributeClass is null)
+            {
+                continue;
+            }
+
+            if (attributeClass.Name != RegisterHandlerAttributeName ||
+                attributeClass.ContainingNamespace?.ToDisplayString() != RegisterHandlerNamespace)
+            {
+                continue;
+            }
+
+            lifetime = attribute.ConstructorArguments.Length > 0 && attribute.ConstructorArguments[0].Value is int value
+                ? value switch
+                {
+                    0 => Lifetime.Singleton,
+                    2 => Lifetime.Transient,
+                    _ => Lifetime.Scoped,
+                }
+                : Lifetime.Scoped;
+            return true;
+        }
+
+        lifetime = string.Empty;
+        return false;
+    }
+
+    private static class Lifetime
+    {
+        public const string Singleton = "Singleton";
+        public const string Scoped = "Scoped";
+        public const string Transient = "Transient";
+    }
+}


### PR DESCRIPTION
## Summary
- New `Mediarq.Analyzers` diagnostic **`MQ200`** (warning): flags a handler/behavior/validator explicitly registered `[RegisterHandler(ServiceLifetime.Singleton)]` whose constructor depends on a `DbContext`, or another Mediarq type explicitly registered `Scoped`/`Transient` — a captive dependency (the shorter-lived instance gets resolved once and captured for the app's whole lifetime).
- Deliberately conservative: only compares **explicit** lifetimes on both sides (the `[RegisterHandler(...)]` attribute, or a `DbContext`-derived parameter type by base-type walk). No visibility into a consumer's arbitrary `services.AddScoped<T>()` calls outside the Mediarq registration model, so it stays silent there rather than guess and risk a false positive — per the backlog note ("faux positifs probables").
- Documented in `docs/guides/troubleshooting.md` (new "Lifetime" section) and the CHANGELOG.
- Closes #84, closes #64 (duplicate backlog entries for the same item).

## Test plan
- [x] `dotnet test Tests/Mediarq.Analyzers.Tests` — 24/24 passing (17 existing MediatR-migration tests + 7 new: DbContext dependency, explicit Scoped dependency, explicit Transient dependency, Singleton-on-Singleton not flagged, undecorated dependency not flagged, non-Singleton type not flagged, plain code not flagged)
- [x] `dotnet build Mediarq.sln` — 0 warnings, 0 errors