### PR TITLE
feat(idempotency): add Mediarq.Idempotency.EntityFrameworkCore persistent store

### DIFF
--- a/Mediarq.sln
+++ b/Mediarq.sln
@@ -79,6 +79,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mediarq.Analyzers", "src\Me
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mediarq.Analyzers.Tests", "Tests\Mediarq.Analyzers.Tests\Mediarq.Analyzers.Tests.csproj", "{0B1DFCF9-A4A8-4AA8-86C0-ACFC37C51CC8}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mediarq.Idempotency.EntityFrameworkCore", "src\Mediarq.Idempotency.EntityFrameworkCore\Mediarq.Idempotency.EntityFrameworkCore.csproj", "{C90F03E5-A869-47D4-9203-95CE3C88E095}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mediarq.Idempotency.EntityFrameworkCore.Tests", "Tests\Mediarq.Idempotency.EntityFrameworkCore.Tests\Mediarq.Idempotency.EntityFrameworkCore.Tests.csproj", "{D759E3BD-DFAE-413D-9C4F-7EB0DE5991E4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -497,6 +501,30 @@ Global
 		{0B1DFCF9-A4A8-4AA8-86C0-ACFC37C51CC8}.Release|x64.Build.0 = Release|Any CPU
 		{0B1DFCF9-A4A8-4AA8-86C0-ACFC37C51CC8}.Release|x86.ActiveCfg = Release|Any CPU
 		{0B1DFCF9-A4A8-4AA8-86C0-ACFC37C51CC8}.Release|x86.Build.0 = Release|Any CPU
+		{C90F03E5-A869-47D4-9203-95CE3C88E095}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C90F03E5-A869-47D4-9203-95CE3C88E095}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C90F03E5-A869-47D4-9203-95CE3C88E095}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C90F03E5-A869-47D4-9203-95CE3C88E095}.Debug|x64.Build.0 = Debug|Any CPU
+		{C90F03E5-A869-47D4-9203-95CE3C88E095}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C90F03E5-A869-47D4-9203-95CE3C88E095}.Debug|x86.Build.0 = Debug|Any CPU
+		{C90F03E5-A869-47D4-9203-95CE3C88E095}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C90F03E5-A869-47D4-9203-95CE3C88E095}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C90F03E5-A869-47D4-9203-95CE3C88E095}.Release|x64.ActiveCfg = Release|Any CPU
+		{C90F03E5-A869-47D4-9203-95CE3C88E095}.Release|x64.Build.0 = Release|Any CPU
+		{C90F03E5-A869-47D4-9203-95CE3C88E095}.Release|x86.ActiveCfg = Release|Any CPU
+		{C90F03E5-A869-47D4-9203-95CE3C88E095}.Release|x86.Build.0 = Release|Any CPU
+		{D759E3BD-DFAE-413D-9C4F-7EB0DE5991E4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D759E3BD-DFAE-413D-9C4F-7EB0DE5991E4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D759E3BD-DFAE-413D-9C4F-7EB0DE5991E4}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D759E3BD-DFAE-413D-9C4F-7EB0DE5991E4}.Debug|x64.Build.0 = Debug|Any CPU
+		{D759E3BD-DFAE-413D-9C4F-7EB0DE5991E4}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D759E3BD-DFAE-413D-9C4F-7EB0DE5991E4}.Debug|x86.Build.0 = Debug|Any CPU
+		{D759E3BD-DFAE-413D-9C4F-7EB0DE5991E4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D759E3BD-DFAE-413D-9C4F-7EB0DE5991E4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D759E3BD-DFAE-413D-9C4F-7EB0DE5991E4}.Release|x64.ActiveCfg = Release|Any CPU
+		{D759E3BD-DFAE-413D-9C4F-7EB0DE5991E4}.Release|x64.Build.0 = Release|Any CPU
+		{D759E3BD-DFAE-413D-9C4F-7EB0DE5991E4}.Release|x86.ActiveCfg = Release|Any CPU
+		{D759E3BD-DFAE-413D-9C4F-7EB0DE5991E4}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -536,6 +564,8 @@ Global
 		{2B29BC65-2030-4858-821A-A8C65164BC4F} = {FF7A3C67-F591-440B-B6A5-4A9A9897F3B2}
 		{302A6547-1D57-41AF-B38C-EDFC8DD9970F} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 		{0B1DFCF9-A4A8-4AA8-86C0-ACFC37C51CC8} = {241BFF49-BD9F-4E8B-855A-55286E3474C1}
+		{C90F03E5-A869-47D4-9203-95CE3C88E095} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{D759E3BD-DFAE-413D-9C4F-7EB0DE5991E4} = {241BFF49-BD9F-4E8B-855A-55286E3474C1}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {A8B20815-FE51-42E4-8A6E-E12A17B80DFD}

--- a/Tests/Mediarq.Idempotency.EntityFrameworkCore.Tests/EfCoreDistributedCacheTests.cs
+++ b/Tests/Mediarq.Idempotency.EntityFrameworkCore.Tests/EfCoreDistributedCacheTests.cs
@@ -1,0 +1,118 @@
+using FluentAssertions;
+using Mediarq.Idempotency.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Distributed;
+
+namespace Mediarq.Idempotency.EntityFrameworkCore.Tests;
+
+public sealed class IdempotencyTestDbContext(DbContextOptions<IdempotencyTestDbContext> options) : DbContext(options)
+{
+    protected override void OnModelCreating(ModelBuilder modelBuilder) => modelBuilder.ApplyMediarqIdempotencyCache();
+}
+
+public class EfCoreDistributedCacheTests
+{
+    private static IdempotencyTestDbContext NewContext()
+        => new(new DbContextOptionsBuilder<IdempotencyTestDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options);
+
+    [Fact]
+    public async Task SetAsync_Then_GetAsync_Roundtrips_The_Value()
+    {
+        await using var context = NewContext();
+        var cache = new EfCoreDistributedCache<IdempotencyTestDbContext>(context);
+
+        await cache.SetAsync("key-1", [1, 2, 3], new DistributedCacheEntryOptions());
+        var value = await cache.GetAsync("key-1");
+
+        value.Should().Equal(1, 2, 3);
+    }
+
+    [Fact]
+    public async Task GetAsync_Returns_Null_For_An_Unknown_Key()
+    {
+        await using var context = NewContext();
+        var cache = new EfCoreDistributedCache<IdempotencyTestDbContext>(context);
+
+        var value = await cache.GetAsync("missing");
+
+        value.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetAsync_Returns_Null_And_Evicts_An_Expired_Entry()
+    {
+        await using var context = NewContext();
+        var cache = new EfCoreDistributedCache<IdempotencyTestDbContext>(context);
+
+        await cache.SetAsync("key-1", [1], new DistributedCacheEntryOptions
+        {
+            AbsoluteExpirationRelativeToNow = TimeSpan.FromMilliseconds(1),
+        });
+        await Task.Delay(20);
+
+        var value = await cache.GetAsync("key-1");
+
+        value.Should().BeNull();
+        (await context.Set<IdempotencyCacheEntry>().AnyAsync(e => e.Key == "key-1")).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task SetAsync_Overwrites_An_Existing_Entry()
+    {
+        await using var context = NewContext();
+        var cache = new EfCoreDistributedCache<IdempotencyTestDbContext>(context);
+
+        await cache.SetAsync("key-1", [1], new DistributedCacheEntryOptions());
+        await cache.SetAsync("key-1", [2, 2], new DistributedCacheEntryOptions());
+
+        var value = await cache.GetAsync("key-1");
+        value.Should().Equal(2, 2);
+        (await context.Set<IdempotencyCacheEntry>().CountAsync()).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task RemoveAsync_Deletes_The_Entry()
+    {
+        await using var context = NewContext();
+        var cache = new EfCoreDistributedCache<IdempotencyTestDbContext>(context);
+
+        await cache.SetAsync("key-1", [1], new DistributedCacheEntryOptions());
+        await cache.RemoveAsync("key-1");
+
+        (await cache.GetAsync("key-1")).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetAsync_Extends_ExpiresAtUtc_Under_A_Sliding_Expiration()
+    {
+        await using var context = NewContext();
+        var cache = new EfCoreDistributedCache<IdempotencyTestDbContext>(context);
+
+        await cache.SetAsync("key-1", [1], new DistributedCacheEntryOptions
+        {
+            SlidingExpiration = TimeSpan.FromMinutes(10),
+        });
+        var firstExpiry = (await context.Set<IdempotencyCacheEntry>().SingleAsync()).ExpiresAtUtc;
+
+        await Task.Delay(20);
+        await cache.GetAsync("key-1");
+        var secondExpiry = (await context.Set<IdempotencyCacheEntry>().SingleAsync()).ExpiresAtUtc;
+
+        secondExpiry.Should().BeAfter(firstExpiry!.Value);
+    }
+
+    [Fact]
+    public void Sync_Get_Set_Remove_Delegate_To_The_Async_Members()
+    {
+        using var context = NewContext();
+        var cache = new EfCoreDistributedCache<IdempotencyTestDbContext>(context);
+
+        cache.Set("key-1", [9], new DistributedCacheEntryOptions());
+        cache.Get("key-1").Should().Equal(9);
+
+        cache.Remove("key-1");
+        cache.Get("key-1").Should().BeNull();
+    }
+}

--- a/Tests/Mediarq.Idempotency.EntityFrameworkCore.Tests/IdempotencyBehaviorIntegrationTests.cs
+++ b/Tests/Mediarq.Idempotency.EntityFrameworkCore.Tests/IdempotencyBehaviorIntegrationTests.cs
@@ -1,0 +1,54 @@
+using FluentAssertions;
+using Mediarq.Caching;
+using Mediarq.Core.Common.Contexts;
+using Mediarq.Core.Common.Requests.Command;
+using Mediarq.Core.Common.Results;
+using Mediarq.Idempotency;
+using Microsoft.EntityFrameworkCore;
+
+namespace Mediarq.Idempotency.EntityFrameworkCore.Tests;
+
+/// <summary>
+/// End-to-end check that <see cref="IdempotencyBehavior{TRequest, TResponse}"/> — unchanged, still
+/// depending on the plain <c>IDistributedCache</c> abstraction — works against
+/// <see cref="EfCoreDistributedCache{TContext}"/> exactly like it does against any other implementation.
+/// </summary>
+public class IdempotencyBehaviorIntegrationTests
+{
+    public record PayCommand(string Key, decimal Amount) : ICommand<Result<string>>, IIdempotentRequest
+    {
+        public string IdempotencyKey => Key;
+    }
+
+    private static IdempotencyTestDbContext NewContext()
+        => new(new DbContextOptionsBuilder<IdempotencyTestDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options);
+
+    [Fact]
+    public async Task Replays_Stored_Result_And_Runs_Handler_Once_For_Same_Key()
+    {
+        await using var context = NewContext();
+        var cache = new EfCoreDistributedCache<IdempotencyTestDbContext>(context);
+        var behavior = new IdempotencyBehavior<PayCommand, Result<string>>(cache, new JsonMediarqCacheSerializer());
+
+        var calls = 0;
+        Task<Result<string>> Handle()
+        {
+            calls++;
+            return Task.FromResult(Result.Success($"receipt-{calls}"));
+        }
+
+        var requestContext = new RequestContext<PayCommand, Result<string>>(new PayCommand("order-1", 10m), "user");
+
+        var first = await behavior.Handle(requestContext, Handle);
+        var second = await behavior.Handle(requestContext, Handle);
+
+        calls.Should().Be(1);
+        first.Value.Should().Be("receipt-1");
+        second.Value.Should().Be("receipt-1");
+
+        // The result really did round-trip through the database, not an in-process cache.
+        (await context.Set<IdempotencyCacheEntry>().CountAsync()).Should().Be(1);
+    }
+}

--- a/Tests/Mediarq.Idempotency.EntityFrameworkCore.Tests/IdempotencyCacheCleanupServiceTests.cs
+++ b/Tests/Mediarq.Idempotency.EntityFrameworkCore.Tests/IdempotencyCacheCleanupServiceTests.cs
@@ -1,0 +1,46 @@
+using FluentAssertions;
+using Mediarq.Idempotency.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Mediarq.Idempotency.EntityFrameworkCore.Tests;
+
+public class IdempotencyCacheCleanupServiceTests
+{
+    private static ServiceProvider BuildProvider(string databaseName)
+    {
+        var services = new ServiceCollection();
+        services.AddDbContext<IdempotencyTestDbContext>(o => o.UseInMemoryDatabase(databaseName));
+        return services.BuildServiceProvider();
+    }
+
+    [Fact]
+    public async Task Sweep_Removes_Expired_Entries_But_Keeps_Live_Ones()
+    {
+        var databaseName = Guid.NewGuid().ToString();
+        await using (var provider = BuildProvider(databaseName))
+        {
+            await using var context = provider.GetRequiredService<IdempotencyTestDbContext>();
+            var cache = new EfCoreDistributedCache<IdempotencyTestDbContext>(context);
+
+            await cache.SetAsync("expired", [1], new DistributedCacheEntryOptions { AbsoluteExpirationRelativeToNow = TimeSpan.FromMilliseconds(1) });
+            await cache.SetAsync("live", [2], new DistributedCacheEntryOptions { AbsoluteExpirationRelativeToNow = TimeSpan.FromHours(1) });
+            await cache.SetAsync("no-expiry", [3], new DistributedCacheEntryOptions());
+            await Task.Delay(20);
+        }
+
+        await using var sweepProvider = BuildProvider(databaseName);
+        var service = new IdempotencyCacheCleanupService<IdempotencyTestDbContext>(
+            sweepProvider.GetRequiredService<IServiceScopeFactory>(),
+            new IdempotencyCacheOptions { CleanupInterval = TimeSpan.FromMilliseconds(10) });
+
+        await service.StartAsync(CancellationToken.None);
+        await Task.Delay(50);
+        await service.StopAsync(CancellationToken.None);
+
+        await using var verifyContext = sweepProvider.GetRequiredService<IdempotencyTestDbContext>();
+        var remainingKeys = await verifyContext.Set<IdempotencyCacheEntry>().Select(e => e.Key).ToListAsync();
+        remainingKeys.Should().BeEquivalentTo("live", "no-expiry");
+    }
+}

--- a/Tests/Mediarq.Idempotency.EntityFrameworkCore.Tests/Mediarq.Idempotency.EntityFrameworkCore.Tests.csproj
+++ b/Tests/Mediarq.Idempotency.EntityFrameworkCore.Tests/Mediarq.Idempotency.EntityFrameworkCore.Tests.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="8.7.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.10" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.10" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Mediarq.Idempotency.EntityFrameworkCore\Mediarq.Idempotency.EntityFrameworkCore.csproj" />
+    <ProjectReference Include="..\..\src\Mediarq.Idempotency\Mediarq.Idempotency.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,6 +25,9 @@ commands, queries, notifications, a composable pipeline of behaviors, built-in v
 | `Mediarq.EntityFrameworkCore` | `IUnitOfWork` over a `DbContext` |
 | `Mediarq.Polly` | Resilience (retry/timeout/circuit breaker) via Polly |
 | `Mediarq.MassTransit` | Publish notifications out-of-process on a MassTransit bus |
+| `Mediarq.Idempotency` | Run a request at most once per key (`IIdempotentRequest`) |
+| `Mediarq.Idempotency.EntityFrameworkCore` | EF Core-backed `IDistributedCache` for `Mediarq.Idempotency`, no Redis required |
+| `Mediarq.Outbox` | Transactional outbox over EF Core (capture + reliable background publish) |
 
 ## Guides
 

--- a/src/Mediarq.Idempotency.EntityFrameworkCore/EfCoreDistributedCache.cs
+++ b/src/Mediarq.Idempotency.EntityFrameworkCore/EfCoreDistributedCache.cs
@@ -1,0 +1,127 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Distributed;
+
+namespace Mediarq.Idempotency.EntityFrameworkCore;
+
+/// <summary>
+/// <see cref="IDistributedCache"/> backed by an EF Core <typeparamref name="TContext"/>, so
+/// <c>Mediarq.Idempotency</c>'s <c>IdempotencyBehavior</c> can persist replay results in your own
+/// database instead of requiring Redis.
+/// </summary>
+/// <typeparam name="TContext">The EF Core <see cref="DbContext"/> that maps <see cref="IdempotencyCacheEntry"/>.</typeparam>
+/// <remarks>
+/// Registered <b>scoped</b> (see <see cref="IdempotencyCacheServiceCollectionExtensions.AddMediarqIdempotencyEntityFrameworkCore{TContext}"/>),
+/// tied to the same <typeparamref name="TContext"/> instance as the rest of the request — unlike the
+/// usual singleton <c>IDistributedCache</c> implementations (in-memory, Redis). Do not resolve it
+/// outside a scope, and do not share it with singleton consumers unrelated to Mediarq.Idempotency.
+/// </remarks>
+public sealed class EfCoreDistributedCache<TContext> : IDistributedCache
+    where TContext : DbContext
+{
+    private readonly TContext _context;
+
+    /// <summary>Initializes a new instance wrapping <paramref name="context"/>.</summary>
+    /// <param name="context">The EF Core context that holds the idempotency cache table.</param>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="context"/> is <see langword="null"/>.</exception>
+    public EfCoreDistributedCache(TContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        _context = context;
+    }
+
+    /// <inheritdoc />
+    public byte[]? Get(string key) => GetAsync(key).GetAwaiter().GetResult();
+
+    /// <inheritdoc />
+    public async Task<byte[]?> GetAsync(string key, CancellationToken token = default)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+
+        var entry = await FindAsync(key, token).ConfigureAwait(false);
+        if (entry is null)
+        {
+            return null;
+        }
+
+        var now = DateTimeOffset.UtcNow;
+        if (entry.ExpiresAtUtc is { } expiresAt && expiresAt <= now)
+        {
+            _context.Set<IdempotencyCacheEntry>().Remove(entry);
+            await _context.SaveChangesAsync(token).ConfigureAwait(false);
+            return null;
+        }
+
+        if (entry.SlidingExpiration is { } sliding)
+        {
+            var renewed = now + sliding;
+            entry.ExpiresAtUtc = entry.AbsoluteExpiration is { } absolute && renewed > absolute ? absolute : renewed;
+            await _context.SaveChangesAsync(token).ConfigureAwait(false);
+        }
+
+        return entry.Value;
+    }
+
+    /// <inheritdoc />
+    public void Refresh(string key) => RefreshAsync(key).GetAwaiter().GetResult();
+
+    /// <inheritdoc />
+    public Task RefreshAsync(string key, CancellationToken token = default) =>
+        // Reading already applies the sliding-expiration renewal as a side effect.
+        GetAsync(key, token);
+
+    /// <inheritdoc />
+    public void Remove(string key) => RemoveAsync(key).GetAwaiter().GetResult();
+
+    /// <inheritdoc />
+    public async Task RemoveAsync(string key, CancellationToken token = default)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+
+        var entry = await FindAsync(key, token).ConfigureAwait(false);
+        if (entry is null)
+        {
+            return;
+        }
+
+        _context.Set<IdempotencyCacheEntry>().Remove(entry);
+        await _context.SaveChangesAsync(token).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public void Set(string key, byte[] value, DistributedCacheEntryOptions options) =>
+        SetAsync(key, value, options).GetAwaiter().GetResult();
+
+    /// <inheritdoc />
+    public async Task SetAsync(string key, byte[] value, DistributedCacheEntryOptions options, CancellationToken token = default)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+        ArgumentNullException.ThrowIfNull(value);
+        ArgumentNullException.ThrowIfNull(options);
+
+        var now = DateTimeOffset.UtcNow;
+        var absolute = options.AbsoluteExpiration;
+        if (options.AbsoluteExpirationRelativeToNow is { } relativeToNow)
+        {
+            absolute = now + relativeToNow;
+        }
+
+        var expiresAt = absolute ?? (options.SlidingExpiration is { } sliding ? now + sliding : (DateTimeOffset?)null);
+
+        var entry = await FindAsync(key, token).ConfigureAwait(false);
+        if (entry is null)
+        {
+            entry = new IdempotencyCacheEntry { Key = key };
+            _context.Set<IdempotencyCacheEntry>().Add(entry);
+        }
+
+        entry.Value = value;
+        entry.AbsoluteExpiration = absolute;
+        entry.SlidingExpiration = options.SlidingExpiration;
+        entry.ExpiresAtUtc = expiresAt;
+
+        await _context.SaveChangesAsync(token).ConfigureAwait(false);
+    }
+
+    private Task<IdempotencyCacheEntry?> FindAsync(string key, CancellationToken cancellationToken) =>
+        _context.Set<IdempotencyCacheEntry>().FirstOrDefaultAsync(e => e.Key == key, cancellationToken);
+}

--- a/src/Mediarq.Idempotency.EntityFrameworkCore/IdempotencyCacheCleanupService.cs
+++ b/src/Mediarq.Idempotency.EntityFrameworkCore/IdempotencyCacheCleanupService.cs
@@ -1,0 +1,93 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Mediarq.Idempotency.EntityFrameworkCore;
+
+/// <summary>
+/// Background service that periodically removes expired <see cref="IdempotencyCacheEntry"/> rows from
+/// <typeparamref name="TContext"/>. Expired entries are already ignored on read
+/// (<see cref="EfCoreDistributedCache{TContext}.GetAsync"/>); this only reclaims storage for keys that
+/// are never read again after expiring.
+/// </summary>
+/// <typeparam name="TContext">The EF Core <see cref="DbContext"/> that maps <see cref="IdempotencyCacheEntry"/>.</typeparam>
+public sealed class IdempotencyCacheCleanupService<TContext> : BackgroundService
+    where TContext : DbContext
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly IdempotencyCacheOptions _options;
+    private readonly ILogger<IdempotencyCacheCleanupService<TContext>>? _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="IdempotencyCacheCleanupService{TContext}"/> class.
+    /// </summary>
+    /// <param name="scopeFactory">Factory used to create a scope per sweep (for a scoped context).</param>
+    /// <param name="options">The cleanup options (interval, batch size).</param>
+    /// <param name="logger">Optional logger for cleanup errors.</param>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="scopeFactory"/> or <paramref name="options"/> is <see langword="null"/>.</exception>
+    public IdempotencyCacheCleanupService(IServiceScopeFactory scopeFactory, IdempotencyCacheOptions options, ILogger<IdempotencyCacheCleanupService<TContext>>? logger = null)
+    {
+        ArgumentNullException.ThrowIfNull(scopeFactory);
+        ArgumentNullException.ThrowIfNull(options);
+        _scopeFactory = scopeFactory;
+        _options = options;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        using var timer = new PeriodicTimer(_options.CleanupInterval);
+
+        do
+        {
+            try
+            {
+                await CleanupOnceAsync(stoppingToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogError(ex, "Mediarq idempotency cache cleanup failed; will retry on the next sweep.");
+            }
+        }
+        while (await WaitForNextTickAsync(timer, stoppingToken).ConfigureAwait(false));
+    }
+
+    private async Task CleanupOnceAsync(CancellationToken cancellationToken)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<TContext>();
+
+        var now = DateTimeOffset.UtcNow;
+        var expired = await context.Set<IdempotencyCacheEntry>()
+            .Where(e => e.ExpiresAtUtc != null && e.ExpiresAtUtc <= now)
+            .Take(_options.CleanupBatchSize)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        if (expired.Count == 0)
+        {
+            return;
+        }
+
+        context.Set<IdempotencyCacheEntry>().RemoveRange(expired);
+        await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task<bool> WaitForNextTickAsync(PeriodicTimer timer, CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await timer.WaitForNextTickAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            return false;
+        }
+    }
+}

--- a/src/Mediarq.Idempotency.EntityFrameworkCore/IdempotencyCacheEntry.cs
+++ b/src/Mediarq.Idempotency.EntityFrameworkCore/IdempotencyCacheEntry.cs
@@ -1,0 +1,22 @@
+namespace Mediarq.Idempotency.EntityFrameworkCore;
+
+/// <summary>
+/// A persisted cache entry backing <see cref="EfCoreDistributedCache{TContext}"/>.
+/// </summary>
+public sealed class IdempotencyCacheEntry
+{
+    /// <summary>Gets or sets the cache key.</summary>
+    public string Key { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the cached value.</summary>
+    public byte[] Value { get; set; } = [];
+
+    /// <summary>Gets or sets the hard expiration ceiling, if any (<c>AbsoluteExpiration</c>/<c>AbsoluteExpirationRelativeToNow</c>).</summary>
+    public DateTimeOffset? AbsoluteExpiration { get; set; }
+
+    /// <summary>Gets or sets the sliding expiration window, if any; extends <see cref="ExpiresAtUtc"/> on each read, capped by <see cref="AbsoluteExpiration"/>.</summary>
+    public TimeSpan? SlidingExpiration { get; set; }
+
+    /// <summary>Gets or sets when this entry currently expires; <see langword="null"/> means it never expires.</summary>
+    public DateTimeOffset? ExpiresAtUtc { get; set; }
+}

--- a/src/Mediarq.Idempotency.EntityFrameworkCore/IdempotencyCacheModelBuilderExtensions.cs
+++ b/src/Mediarq.Idempotency.EntityFrameworkCore/IdempotencyCacheModelBuilderExtensions.cs
@@ -1,0 +1,31 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Mediarq.Idempotency.EntityFrameworkCore;
+
+/// <summary>
+/// EF Core model configuration for the Mediarq idempotency cache.
+/// </summary>
+public static class IdempotencyCacheModelBuilderExtensions
+{
+    /// <summary>
+    /// Maps the <see cref="IdempotencyCacheEntry"/> entity. Call from your <c>DbContext.OnModelCreating</c>.
+    /// </summary>
+    /// <param name="modelBuilder">The model builder to configure.</param>
+    /// <returns>The same model builder, enabling fluent chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="modelBuilder"/> is <see langword="null"/>.</exception>
+    public static ModelBuilder ApplyMediarqIdempotencyCache(this ModelBuilder modelBuilder)
+    {
+        ArgumentNullException.ThrowIfNull(modelBuilder);
+
+        var entity = modelBuilder.Entity<IdempotencyCacheEntry>();
+        entity.HasKey(e => e.Key);
+        // 449 matches the max key length SQL Server can index (900 byte limit / typical multi-byte
+        // collation); keeps the table indexable across providers without a provider-specific override.
+        entity.Property(e => e.Key).HasMaxLength(449);
+        entity.Property(e => e.Value).IsRequired();
+        // Speeds up the cleanup service's "expired entries" query.
+        entity.HasIndex(e => e.ExpiresAtUtc);
+
+        return modelBuilder;
+    }
+}

--- a/src/Mediarq.Idempotency.EntityFrameworkCore/IdempotencyCacheOptions.cs
+++ b/src/Mediarq.Idempotency.EntityFrameworkCore/IdempotencyCacheOptions.cs
@@ -1,0 +1,11 @@
+namespace Mediarq.Idempotency.EntityFrameworkCore;
+
+/// <summary>Options controlling the <see cref="IdempotencyCacheCleanupService{TContext}"/>.</summary>
+public sealed class IdempotencyCacheOptions
+{
+    /// <summary>Gets or sets how often the cleanup service sweeps for expired entries. Default: 5 minutes.</summary>
+    public TimeSpan CleanupInterval { get; set; } = TimeSpan.FromMinutes(5);
+
+    /// <summary>Gets or sets the maximum number of expired entries removed per sweep. Default: 200.</summary>
+    public int CleanupBatchSize { get; set; } = 200;
+}

--- a/src/Mediarq.Idempotency.EntityFrameworkCore/IdempotencyCacheServiceCollectionExtensions.cs
+++ b/src/Mediarq.Idempotency.EntityFrameworkCore/IdempotencyCacheServiceCollectionExtensions.cs
@@ -1,0 +1,46 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Mediarq.Idempotency.EntityFrameworkCore;
+
+/// <summary>
+/// Extension methods that wire an EF Core-backed <see cref="IDistributedCache"/> for Mediarq.Idempotency.
+/// </summary>
+public static class IdempotencyCacheServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers <see cref="EfCoreDistributedCache{TContext}"/> as the <see cref="IDistributedCache"/>
+    /// used by <c>Mediarq.Idempotency</c>, plus a background service that periodically removes expired
+    /// entries.
+    /// </summary>
+    /// <typeparam name="TContext">
+    /// The EF Core <see cref="DbContext"/> that maps <see cref="IdempotencyCacheEntry"/>
+    /// (see <see cref="IdempotencyCacheModelBuilderExtensions.ApplyMediarqIdempotencyCache"/>).
+    /// </typeparam>
+    /// <param name="services">The service collection to configure.</param>
+    /// <param name="configure">Optional callback to tune the cleanup service (interval, batch size).</param>
+    /// <returns>The same service collection, enabling fluent chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="services"/> is <see langword="null"/>.</exception>
+    /// <remarks>
+    /// Call instead of <c>AddDistributedMemoryCache()</c> / <c>AddStackExchangeRedisCache()</c>, before
+    /// <c>AddMediarqIdempotency()</c>. Map the cache table by calling
+    /// <c>ApplyMediarqIdempotencyCache()</c> in your context's <c>OnModelCreating</c>.
+    /// </remarks>
+    public static IServiceCollection AddMediarqIdempotencyEntityFrameworkCore<TContext>(this IServiceCollection services, Action<IdempotencyCacheOptions>? configure = null)
+        where TContext : DbContext
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        var options = new IdempotencyCacheOptions();
+        configure?.Invoke(options);
+
+        services.TryAddSingleton(options);
+        // Scoped, not singleton: this implementation is tied to the scoped TContext instance.
+        services.AddScoped<IDistributedCache, EfCoreDistributedCache<TContext>>();
+        services.AddHostedService<IdempotencyCacheCleanupService<TContext>>();
+
+        return services;
+    }
+}

--- a/src/Mediarq.Idempotency.EntityFrameworkCore/Mediarq.Idempotency.EntityFrameworkCore.csproj
+++ b/src/Mediarq.Idempotency.EntityFrameworkCore/Mediarq.Idempotency.EntityFrameworkCore.csproj
@@ -1,0 +1,37 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <PackageId>Mediarq.Idempotency.EntityFrameworkCore</PackageId>
+    <Version>1.0.0</Version>
+    <Authors>Nicolas Rouffart</Authors>
+    <Description>EF Core-backed IDistributedCache for Mediarq.Idempotency: a persistent, queryable idempotency store over a DbContext, as an alternative to Redis or in-memory. Includes a background cleanup service for expired entries.</Description>
+    <PackageTags>mediarq;cqrs;idempotency;entityframeworkcore;efcore;dotnet</PackageTags>
+    <PackageProjectUrl>https://github.com/rouffou/mediarq</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/rouffou/mediarq</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Mediarq.Idempotency.EntityFrameworkCore.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+</Project>

--- a/src/Mediarq.Idempotency.EntityFrameworkCore/PublicAPI.Shipped.txt
+++ b/src/Mediarq.Idempotency.EntityFrameworkCore/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Mediarq.Idempotency.EntityFrameworkCore/PublicAPI.Unshipped.txt
+++ b/src/Mediarq.Idempotency.EntityFrameworkCore/PublicAPI.Unshipped.txt
@@ -1,0 +1,35 @@
+#nullable enable
+Mediarq.Idempotency.EntityFrameworkCore.EfCoreDistributedCache<TContext>
+Mediarq.Idempotency.EntityFrameworkCore.EfCoreDistributedCache<TContext>.EfCoreDistributedCache(TContext! context) -> void
+Mediarq.Idempotency.EntityFrameworkCore.EfCoreDistributedCache<TContext>.Get(string! key) -> byte[]?
+Mediarq.Idempotency.EntityFrameworkCore.EfCoreDistributedCache<TContext>.GetAsync(string! key, System.Threading.CancellationToken token = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<byte[]?>!
+Mediarq.Idempotency.EntityFrameworkCore.EfCoreDistributedCache<TContext>.Refresh(string! key) -> void
+Mediarq.Idempotency.EntityFrameworkCore.EfCoreDistributedCache<TContext>.RefreshAsync(string! key, System.Threading.CancellationToken token = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Mediarq.Idempotency.EntityFrameworkCore.EfCoreDistributedCache<TContext>.Remove(string! key) -> void
+Mediarq.Idempotency.EntityFrameworkCore.EfCoreDistributedCache<TContext>.RemoveAsync(string! key, System.Threading.CancellationToken token = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Mediarq.Idempotency.EntityFrameworkCore.EfCoreDistributedCache<TContext>.Set(string! key, byte[]! value, Microsoft.Extensions.Caching.Distributed.DistributedCacheEntryOptions! options) -> void
+Mediarq.Idempotency.EntityFrameworkCore.EfCoreDistributedCache<TContext>.SetAsync(string! key, byte[]! value, Microsoft.Extensions.Caching.Distributed.DistributedCacheEntryOptions! options, System.Threading.CancellationToken token = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Mediarq.Idempotency.EntityFrameworkCore.IdempotencyCacheCleanupService<TContext>
+Mediarq.Idempotency.EntityFrameworkCore.IdempotencyCacheCleanupService<TContext>.IdempotencyCacheCleanupService(Microsoft.Extensions.DependencyInjection.IServiceScopeFactory! scopeFactory, Mediarq.Idempotency.EntityFrameworkCore.IdempotencyCacheOptions! options, Microsoft.Extensions.Logging.ILogger<Mediarq.Idempotency.EntityFrameworkCore.IdempotencyCacheCleanupService<TContext!>!>? logger = null) -> void
+Mediarq.Idempotency.EntityFrameworkCore.IdempotencyCacheEntry
+Mediarq.Idempotency.EntityFrameworkCore.IdempotencyCacheEntry.AbsoluteExpiration.get -> System.DateTimeOffset?
+Mediarq.Idempotency.EntityFrameworkCore.IdempotencyCacheEntry.AbsoluteExpiration.set -> void
+Mediarq.Idempotency.EntityFrameworkCore.IdempotencyCacheEntry.ExpiresAtUtc.get -> System.DateTimeOffset?
+Mediarq.Idempotency.EntityFrameworkCore.IdempotencyCacheEntry.ExpiresAtUtc.set -> void
+Mediarq.Idempotency.EntityFrameworkCore.IdempotencyCacheEntry.IdempotencyCacheEntry() -> void
+Mediarq.Idempotency.EntityFrameworkCore.IdempotencyCacheEntry.Key.get -> string!
+Mediarq.Idempotency.EntityFrameworkCore.IdempotencyCacheEntry.Key.set -> void
+Mediarq.Idempotency.EntityFrameworkCore.IdempotencyCacheEntry.SlidingExpiration.get -> System.TimeSpan?
+Mediarq.Idempotency.EntityFrameworkCore.IdempotencyCacheEntry.SlidingExpiration.set -> void
+Mediarq.Idempotency.EntityFrameworkCore.IdempotencyCacheEntry.Value.get -> byte[]!
+Mediarq.Idempotency.EntityFrameworkCore.IdempotencyCacheEntry.Value.set -> void
+Mediarq.Idempotency.EntityFrameworkCore.IdempotencyCacheModelBuilderExtensions
+Mediarq.Idempotency.EntityFrameworkCore.IdempotencyCacheOptions
+Mediarq.Idempotency.EntityFrameworkCore.IdempotencyCacheOptions.CleanupBatchSize.get -> int
+Mediarq.Idempotency.EntityFrameworkCore.IdempotencyCacheOptions.CleanupBatchSize.set -> void
+Mediarq.Idempotency.EntityFrameworkCore.IdempotencyCacheOptions.CleanupInterval.get -> System.TimeSpan
+Mediarq.Idempotency.EntityFrameworkCore.IdempotencyCacheOptions.CleanupInterval.set -> void
+Mediarq.Idempotency.EntityFrameworkCore.IdempotencyCacheOptions.IdempotencyCacheOptions() -> void
+Mediarq.Idempotency.EntityFrameworkCore.IdempotencyCacheServiceCollectionExtensions
+static Mediarq.Idempotency.EntityFrameworkCore.IdempotencyCacheModelBuilderExtensions.ApplyMediarqIdempotencyCache(this Microsoft.EntityFrameworkCore.ModelBuilder! modelBuilder) -> Microsoft.EntityFrameworkCore.ModelBuilder!
+static Mediarq.Idempotency.EntityFrameworkCore.IdempotencyCacheServiceCollectionExtensions.AddMediarqIdempotencyEntityFrameworkCore<TContext>(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, System.Action<Mediarq.Idempotency.EntityFrameworkCore.IdempotencyCacheOptions!>? configure = null) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!

--- a/src/Mediarq.Idempotency.EntityFrameworkCore/README.md
+++ b/src/Mediarq.Idempotency.EntityFrameworkCore/README.md
@@ -1,0 +1,43 @@
+# Mediarq.Idempotency.EntityFrameworkCore
+
+An `IDistributedCache` backed by EF Core, so **Mediarq.Idempotency** can persist replay results in your
+own database instead of requiring Redis.
+
+```bash
+dotnet add package Mediarq.Idempotency.EntityFrameworkCore
+```
+
+## Usage
+
+1. Map the cache table in your `DbContext`:
+```csharp
+protected override void OnModelCreating(ModelBuilder modelBuilder)
+    => modelBuilder.ApplyMediarqIdempotencyCache();
+```
+
+2. Register it **instead of** `AddDistributedMemoryCache()` / `AddStackExchangeRedisCache()`, before
+   `AddMediarqIdempotency()`:
+```csharp
+builder.Services.AddMediarqIdempotencyEntityFrameworkCore<AppDbContext>(o => o.CleanupInterval = TimeSpan.FromMinutes(10));
+builder.Services.AddMediarqIdempotency();
+```
+
+That's it — `IdempotencyBehavior` already depends on the standard `IDistributedCache` abstraction, so it
+works unchanged against this implementation. A background `IdempotencyCacheCleanupService` periodically
+removes expired entries (already-expired entries are also skipped on read, so this is just storage
+hygiene for keys that are never read again after expiring).
+
+## Note on lifetime
+
+`EfCoreDistributedCache<TContext>` is registered **scoped**, tied to the same `TContext` instance as the
+rest of the request — unlike the usual singleton `IDistributedCache` implementations. This is safe for
+`IdempotencyBehavior` (itself scoped), but don't share this registration with a singleton or with a
+general-purpose cache used elsewhere in your app.
+
+## Learn more
+
+[Mediarq.Idempotency](https://www.nuget.org/packages/Mediarq.Idempotency) ·
+[Wiring extensions](https://github.com/rouffou/mediarq/blob/main/docs/guides/wiring-extensions.md) ·
+[Full README](https://github.com/rouffou/mediarq#readme)
+
+MIT © Nicolas Rouffart

--- a/src/Mediarq.Idempotency/README.md
+++ b/src/Mediarq.Idempotency/README.md
@@ -32,6 +32,16 @@ Call after `AddMediarq` / `AddMediarqCore`. Use a stable, caller-supplied key. T
 JSON-serialized; `Result` / `Result<T>` round-trip out of the box. For strict once-only semantics under
 high concurrency, back it with a store that supports atomic set-if-absent (e.g. Redis).
 
+## Persistent stores
+
+`IdempotencyBehavior` depends on the standard `IDistributedCache` — swap the backing store without any
+code change:
+
+- **In-memory** (single process, non-persistent): `AddDistributedMemoryCache()` — shown above.
+- **Redis**: `AddStackExchangeRedisCache(o => o.Configuration = "...")`.
+- **Your own SQL database**: [`Mediarq.Idempotency.EntityFrameworkCore`](https://www.nuget.org/packages/Mediarq.Idempotency.EntityFrameworkCore)
+  — `AddMediarqIdempotencyEntityFrameworkCore<TContext>()`, no Redis required.
+
 ## Learn more
 
 [Wiring extensions](https://github.com/rouffou/mediarq/blob/main/docs/guides/wiring-extensions.md) ·


### PR DESCRIPTION
## Summary
- New package **`Mediarq.Idempotency.EntityFrameworkCore`**: `EfCoreDistributedCache<TContext>`, an `IDistributedCache` backed by an EF Core `DbContext`, so `Mediarq.Idempotency` can persist replay results in your own SQL database instead of requiring Redis.
- `AddMediarqIdempotencyEntityFrameworkCore<TContext>()` registers it — **scoped**, tied to the request's `DbContext` (documented explicitly: don't share with singleton consumers) — plus a background `IdempotencyCacheCleanupService` that periodically sweeps expired entries (already-expired entries are also skipped/evicted on read).
- `ApplyMediarqIdempotencyCache()` maps the `IdempotencyCacheEntry` table.
- **Zero public API break**: `IdempotencyBehavior` is untouched — it already depended on the plain `IDistributedCache` abstraction, which already covers in-memory (`AddDistributedMemoryCache`) and Redis (`AddStackExchangeRedisCache`) via the framework itself. This closes the one genuinely missing backend ("in-memory + EF Core/Redis") without touching the frozen `v1.0.0` API.
- Closes #24.

## Test plan
- [x] `dotnet test Tests/Mediarq.Idempotency.EntityFrameworkCore.Tests` — 9/9 passing: get/set/remove roundtrip, unknown key, expired-entry eviction on read, overwrite, sliding-expiration renewal, sync wrapper methods, cleanup-service sweep (removes expired, keeps live/no-expiry), and an end-to-end integration test proving the unmodified `IdempotencyBehavior` replays correctly against this store
- [x] `dotnet build Mediarq.sln` — 0 warnings, 0 errors
- [x] `dotnet test Mediarq.sln` — all 15 suites green, no regressions