### PR TITLE
docs(readme): free-MediatR-alternative framing + quickstart GIF tape

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,20 @@ built-in validation and `Result` types. Designed for domain-driven and CQRS arch
 
 ---
 
+## Why Mediarq?
+
+MediatR has moved to a commercial license for many users. Mediarq is a drop-in-shaped, **100% free
+and MIT-licensed** mediator: no license tier, no revenue threshold, no future licensing risk — just a
+package you `dotnet add` and keep. It covers the same CQRS building blocks (commands, queries,
+notifications, a behavior pipeline) plus things MediatR doesn't ship out of the box: built-in `Result`
+types, reflection-free/Native AOT dispatch, and a source-generator-driven registration path.
+
+Already on MediatR? The [migration guide](docs/guides/migrating-from-mediatr.md) and its
+[analyzer code-fix provider](docs/guides/migrating-from-mediatr.md#automated-migration-analyzer--code-fix)
+convert most call sites automatically, and
+[`Mediarq.MediatRCompat`](docs/guides/migrating-from-mediatr.md#incremental-migration-large-codebases)
+lets you migrate incrementally in a mixed codebase.
+
 ## Installation
 
 ```bash
@@ -334,6 +348,10 @@ dotnet run --project Samples/Mediarq.Samples.Quickstart
 dotnet run --project Samples/Mediarq.Samples.WebApi      # then open /scalar/v1
 dotnet run --project Samples/Mediarq.AotSample
 ```
+
+> The [Quickstart sample](Samples/Mediarq.Samples.Quickstart) above is what [`assets/quickstart.tape`](assets/quickstart.tape)
+> records into a GIF via [VHS](https://github.com/charmbracelet/vhs) (`vhs assets/quickstart.tape`) — regenerate it whenever
+> the sample's console output changes.
 
 ## Documentation
 

--- a/assets/quickstart.tape
+++ b/assets/quickstart.tape
@@ -1,0 +1,23 @@
+# Quickstart GIF for the README.
+#
+# Renders Samples/Mediarq.Samples.Quickstart running end-to-end, then converts the recording to
+# assets/quickstart.gif. Requires https://github.com/charmbracelet/vhs (which needs ttyd + ffmpeg).
+#
+#   vhs assets/quickstart.tape
+#
+# then embed it in the README with:
+#
+#   ![Mediarq quickstart](assets/quickstart.gif)
+
+Output assets/quickstart.gif
+
+Set Shell "bash"
+Set FontSize 16
+Set Width 1200
+Set Height 800
+Set Theme "Dracula"
+Set Padding 20
+
+Type "dotnet run --project Samples/Mediarq.Samples.Quickstart"
+Enter
+Sleep 8s


### PR DESCRIPTION
## Summary
- Adds a "Why Mediarq?" section to the README, sharpening the free/MIT-vs-MediatR-commercial-license framing and pointing to the migration guide/analyzer/compat shim.
- Adds `assets/quickstart.tape` (a VHS script) that regenerates a quickstart GIF from the `Mediarq.Samples.Quickstart` console output.

## Note
The actual `assets/quickstart.gif` binary is **not** included — rendering it requires running `vhs assets/quickstart.tape` locally (VHS + ttyd + ffmpeg), which isn't available in this environment. Once generated, embed it in the README with `![Mediarq quickstart](assets/quickstart.gif)`.

## Test plan
- [x] Reviewed rendered README locally for broken links/anchors
- [ ] Run `vhs assets/quickstart.tape` and embed the resulting GIF in the README (follow-up)

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)