### PR TITLE
feat(diagnostics): align with OpenTelemetry semantic conventions for messaging

### DIFF
--- a/Tests/Mediarq.Diagnostics.Tests/DiagnosticsBehaviorTests.cs
+++ b/Tests/Mediarq.Diagnostics.Tests/DiagnosticsBehaviorTests.cs
@@ -60,6 +60,75 @@ public class DiagnosticsBehaviorTests
     }
 
     [Fact]
+    public async Task Emits_Messaging_SemanticConvention_Tags_For_Request()
+    {
+        var stopped = new List<Activity>();
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == MediarqDiagnostics.SourceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStopped = stopped.Add,
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        var behavior = new DiagnosticsBehavior<PingQuery, Result<string>>();
+        var context = new RequestContext<PingQuery, Result<string>>(new PingQuery(), "user");
+
+        await behavior.Handle(context, () => Task.FromResult(Result.Success("ok")));
+
+        var activity = stopped.Should().ContainSingle(a => a.OperationName == "Mediarq:PingQuery").Subject;
+        activity.GetTagItem("messaging.system").Should().Be(MediarqDiagnostics.MessagingSystem);
+        activity.GetTagItem("messaging.operation.type").Should().Be("process");
+        activity.GetTagItem("messaging.destination.name").Should().Be(nameof(PingQuery));
+        activity.GetTagItem("messaging.message.id").Should().Be(context.RequestId.ToString());
+    }
+
+    [Fact]
+    public async Task Emits_ErrorType_Tag_When_Request_Throws()
+    {
+        var stopped = new List<Activity>();
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == MediarqDiagnostics.SourceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStopped = stopped.Add,
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        var behavior = new DiagnosticsBehavior<PingQuery, Result<string>>();
+        var context = new RequestContext<PingQuery, Result<string>>(new PingQuery(), "user");
+
+        var act = () => behavior.Handle(context, Task<Result<string>> () => throw new InvalidOperationException("boom"));
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+        var activity = stopped.Should().ContainSingle().Subject;
+        activity.GetTagItem("error.type").Should().Be(typeof(InvalidOperationException).FullName);
+    }
+
+    [Fact]
+    public async Task Records_Messaging_Operation_Duration_Metric_For_Request()
+    {
+        var measurements = 0;
+        using var meterListener = new MeterListener();
+        meterListener.InstrumentPublished = (instrument, l) =>
+        {
+            if (instrument.Meter.Name == MediarqDiagnostics.SourceName && instrument.Name == "messaging.client.operation.duration")
+            {
+                l.EnableMeasurementEvents(instrument);
+            }
+        };
+        meterListener.SetMeasurementEventCallback<double>((_, _, _, _) => Interlocked.Increment(ref measurements));
+        meterListener.Start();
+
+        var behavior = new DiagnosticsBehavior<PingQuery, Result<string>>();
+        var context = new RequestContext<PingQuery, Result<string>>(new PingQuery(), "user");
+
+        await behavior.Handle(context, () => Task.FromResult(Result.Success("ok")));
+
+        measurements.Should().Be(1);
+    }
+
+    [Fact]
     public void AddMediarqDiagnostics_Registers_Behaviors()
     {
         var services = new ServiceCollection();
@@ -93,7 +162,11 @@ public class DiagnosticsBehaviorTests
         }
 
         items.Should().Equal(0, 1, 2);
-        stopped.Should().ContainSingle(a => a.OperationName == "Mediarq:Stream TickStream");
+        var activity = stopped.Should().ContainSingle(a => a.OperationName == "Mediarq:Stream TickStream").Subject;
+        activity.GetTagItem("messaging.system").Should().Be(MediarqDiagnostics.MessagingSystem);
+        activity.GetTagItem("messaging.operation.type").Should().Be("process");
+        activity.GetTagItem("messaging.destination.name").Should().Be(nameof(TickStream));
+        activity.GetTagItem("messaging.batch.message_count").Should().Be(3L);
     }
 
     [Fact]
@@ -115,7 +188,10 @@ public class DiagnosticsBehaviorTests
         await publisher.Publish(handlers, CancellationToken.None);
 
         invoked.Should().BeTrue();
-        stopped.Should().ContainSingle(a => a.OperationName == "Mediarq:Publish");
+        var activity = stopped.Should().ContainSingle(a => a.OperationName == "Mediarq:Publish").Subject;
+        activity.GetTagItem("messaging.system").Should().Be(MediarqDiagnostics.MessagingSystem);
+        activity.GetTagItem("messaging.operation.type").Should().Be("publish");
+        activity.GetTagItem("messaging.batch.message_count").Should().Be(1L);
     }
 
     [Fact]

--- a/docs/assets/observability-dashboard.json
+++ b/docs/assets/observability-dashboard.json
@@ -1,0 +1,144 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "The Prometheus data source scraping your Mediarq app's OTel metrics endpoint.",
+      "type": "datasource",
+      "pluginId": "prometheus"
+    }
+  ],
+  "title": "Mediarq dispatch",
+  "description": "Mediarq.Diagnostics metrics: the original mediarq.* instruments plus the OpenTelemetry messaging semantic convention attributes recorded alongside them. See docs/guides/observability-dashboard.md.",
+  "schemaVersion": 39,
+  "version": 1,
+  "editable": true,
+  "timezone": "",
+  "time": { "from": "now-1h", "to": "now" },
+  "refresh": "30s",
+  "tags": ["mediarq"],
+  "templating": {
+    "list": [
+      {
+        "name": "DS_PROMETHEUS",
+        "type": "datasource",
+        "query": "prometheus",
+        "current": {}
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "row",
+      "title": "Mediarq",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 }
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "Request rate, by request type",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 1 },
+      "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
+      "targets": [
+        {
+          "expr": "sum by (mediarq_request) (rate(mediarq_requests_count_total[5m]))",
+          "legendFormat": "{{mediarq_request}}"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "timeseries",
+      "title": "Error rate (all request types)",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 1 },
+      "fieldConfig": { "defaults": { "unit": "percentunit", "max": 1, "min": 0 }, "overrides": [] },
+      "targets": [
+        {
+          "expr": "sum(rate(mediarq_requests_count_total{mediarq_outcome=\"failure\"}[5m])) / sum(rate(mediarq_requests_count_total[5m]))",
+          "legendFormat": "error rate"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "timeseries",
+      "title": "Duration percentiles (mediarq.requests.duration), by request type",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 9 },
+      "fieldConfig": { "defaults": { "unit": "ms" }, "overrides": [] },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum by (le, mediarq_request) (rate(mediarq_requests_duration_milliseconds_bucket[5m])))",
+          "legendFormat": "p50 {{mediarq_request}}"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le, mediarq_request) (rate(mediarq_requests_duration_milliseconds_bucket[5m])))",
+          "legendFormat": "p95 {{mediarq_request}}"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (le, mediarq_request) (rate(mediarq_requests_duration_milliseconds_bucket[5m])))",
+          "legendFormat": "p99 {{mediarq_request}}"
+        }
+      ]
+    },
+    {
+      "id": 10,
+      "type": "row",
+      "title": "OpenTelemetry messaging semantic conventions",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 17 }
+    },
+    {
+      "id": 11,
+      "type": "timeseries",
+      "title": "Duration percentiles (messaging.client.operation.duration), by destination",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 18 },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum by (le, messaging_destination_name) (rate(messaging_client_operation_duration_seconds_bucket[5m])))",
+          "legendFormat": "p50 {{messaging_destination_name}}"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le, messaging_destination_name) (rate(messaging_client_operation_duration_seconds_bucket[5m])))",
+          "legendFormat": "p95 {{messaging_destination_name}}"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (le, messaging_destination_name) (rate(messaging_client_operation_duration_seconds_bucket[5m])))",
+          "legendFormat": "p99 {{messaging_destination_name}}"
+        }
+      ]
+    },
+    {
+      "id": 12,
+      "type": "timeseries",
+      "title": "Operation rate, by operation type (process = Send/stream, publish = notification)",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 26 },
+      "fieldConfig": { "defaults": { "unit": "ops" }, "overrides": [] },
+      "targets": [
+        {
+          "expr": "sum by (messaging_operation_type) (rate(messaging_client_operation_duration_seconds_count[5m]))",
+          "legendFormat": "{{messaging_operation_type}}"
+        }
+      ]
+    },
+    {
+      "id": 13,
+      "type": "timeseries",
+      "title": "Notification fan-out / stream throughput (avg messaging.batch.message_count)",
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 26 },
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "targets": [
+        {
+          "expr": "rate(messaging_batch_message_count_sum[5m]) / rate(messaging_batch_message_count_count[5m])",
+          "legendFormat": "{{messaging_operation_type}} {{messaging_destination_name}}"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -28,6 +28,9 @@
       { "files": [ "api/**.yml", "api/index.md" ] },
       { "files": [ "*.md", "guides/**.md", "toc.yml" ] }
     ],
+    "resource": [
+      { "files": [ "assets/**" ] }
+    ],
     "dest": "_site",
     "globalMetadata": {
       "_appName": "Mediarq",

--- a/docs/guides/observability-dashboard.md
+++ b/docs/guides/observability-dashboard.md
@@ -1,0 +1,82 @@
+# A ready-to-use dashboard
+
+`Mediarq.Diagnostics` emits both a Mediarq-specific set of tags/metrics (`mediarq.*`, unchanged since
+v1.0 — see [Concepts](concepts.md)) and, alongside them, the subset of the
+[OpenTelemetry semantic conventions for messaging](https://opentelemetry.io/docs/specs/semconv/messaging/)
+that make sense for an in-process mediator: `messaging.system` (`"mediarq"`), `messaging.operation.type`
+(`"process"` for `Send`/streams, `"publish"` for `Publish`), `messaging.destination.name` (the request/
+notification type name), `messaging.message.id`, `messaging.batch.message_count` (handler count for a
+notification, item count for a stream) and the general `error.type` attribute. Nothing existing was
+renamed or removed — this is purely additive, so a dashboard already built on the `mediarq.*` names keeps
+working.
+
+## Wiring
+
+```csharp
+using Mediarq.Diagnostics;
+using Mediarq.OpenTelemetry;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+
+builder.Services.AddMediarqDiagnostics();
+
+builder.Services.AddOpenTelemetry()
+    .WithTracing(tracing => tracing.AddMediarqInstrumentation() /* + your exporter, e.g. .AddOtlpExporter() */)
+    .WithMetrics(metrics => metrics.AddMediarqInstrumentation() /* + your exporter */);
+```
+
+Export however you already do for the rest of your app — OTLP to a collector, or the
+[`OpenTelemetry.Exporter.Prometheus.AspNetCore`](https://www.nuget.org/packages/OpenTelemetry.Exporter.Prometheus.AspNetCore)
+package for a `/metrics` scrape endpoint. The dashboard below assumes Prometheus + Grafana, the most
+common self-hosted combination for OTel metrics, but the underlying instruments work with any backend.
+
+## Importing the dashboard
+
+[`observability-dashboard.json`](../assets/observability-dashboard.json) is a Grafana dashboard you can
+import as-is (Grafana → Dashboards → New → Import → upload the file, pick your Prometheus data source).
+It has two rows:
+
+- **Mediarq** (the original `mediarq.*` instruments): request rate, error rate, p50/p95/p99 duration —
+  all split by `mediarq_request`.
+- **OpenTelemetry messaging semantic conventions**: the same duration percentiles from
+  `messaging_client_operation_duration_seconds`, split by `messaging_operation_type` and
+  `messaging_destination_name`, plus a panel for `messaging_batch_message_count` (notification fan-out /
+  stream item throughput).
+
+> **Metric name suffixes depend on your exporter.** The queries below assume the standard OTel-to-
+> Prometheus naming (dots → underscores, `_total` appended to counters, the unit appended to histograms —
+> e.g. `messaging.client.operation.duration` with unit `s` becomes
+> `messaging_client_operation_duration_seconds_bucket`). Check your own `/metrics` endpoint if a panel
+> comes back empty and adjust the suffix to match.
+
+## Example queries
+
+Request rate, by request type:
+
+```promql
+sum by (mediarq_request) (rate(mediarq_requests_count_total[5m]))
+```
+
+Error rate:
+
+```promql
+sum(rate(mediarq_requests_count_total{mediarq_outcome="failure"}[5m]))
+/ sum(rate(mediarq_requests_count_total[5m]))
+```
+
+p95 duration (OTel messaging semantic convention metric), by destination:
+
+```promql
+histogram_quantile(0.95,
+  sum by (le, messaging_destination_name) (
+    rate(messaging_client_operation_duration_seconds_bucket[5m])
+  )
+)
+```
+
+Notification fan-out (average handlers invoked per publish):
+
+```promql
+rate(messaging_batch_message_count_sum{messaging_operation_type="publish"}[5m])
+/ rate(messaging_batch_message_count_count{messaging_operation_type="publish"}[5m])
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,6 +41,7 @@ New here? Start with **Concepts**, then build **Your first app**.
 - [Testing](guides/testing.md) — unit- and integration-test handlers, validators, behaviors
 - [Migrating from MediatR](guides/migrating-from-mediatr.md)
 - [Native AOT & trimming](guides/native-aot.md)
+- [A ready-to-use observability dashboard](guides/observability-dashboard.md) — import a Grafana dashboard for Mediarq.Diagnostics + OpenTelemetry messaging semantic conventions
 - [Versioning & public API policy](guides/versioning.md) — SemVer rules and the `PublicAPI.*.txt` workflow
 - [Troubleshooting](guides/troubleshooting.md) — when something silently doesn't fire
 

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -18,6 +18,8 @@
       href: guides/mediatr-parity.md
     - name: Native AOT & trimming
       href: guides/native-aot.md
+    - name: A ready-to-use observability dashboard
+      href: guides/observability-dashboard.md
     - name: Versioning & public API policy
       href: guides/versioning.md
     - name: Troubleshooting

--- a/src/Mediarq.Diagnostics/DiagnosticsBehavior.cs
+++ b/src/Mediarq.Diagnostics/DiagnosticsBehavior.cs
@@ -40,13 +40,17 @@ public sealed class DiagnosticsBehavior<TRequest, TResponse> : IPipelineBehavior
         try
         {
             var response = await handle().ConfigureAwait(false);
-            MediarqDiagnostics.Record(RequestName, Stopwatch.GetElapsedTime(startTimestamp), succeeded: true);
+            var elapsed = Stopwatch.GetElapsedTime(startTimestamp);
+            MediarqDiagnostics.Record(RequestName, elapsed, succeeded: true);
+            MediarqDiagnostics.RecordMessagingOperation(activity, "process", RequestName, elapsed, messageId: context.RequestId.ToString());
             activity?.SetStatus(ActivityStatusCode.Ok);
             return response;
         }
         catch (Exception exception)
         {
-            MediarqDiagnostics.Record(RequestName, Stopwatch.GetElapsedTime(startTimestamp), succeeded: false);
+            var elapsed = Stopwatch.GetElapsedTime(startTimestamp);
+            MediarqDiagnostics.Record(RequestName, elapsed, succeeded: false);
+            MediarqDiagnostics.RecordMessagingOperation(activity, "process", RequestName, elapsed, messageId: context.RequestId.ToString(), errorType: exception.GetType().FullName);
             activity?.SetStatus(ActivityStatusCode.Error, exception.Message);
             throw;
         }

--- a/src/Mediarq.Diagnostics/DiagnosticsNotificationPublisher.cs
+++ b/src/Mediarq.Diagnostics/DiagnosticsNotificationPublisher.cs
@@ -39,12 +39,16 @@ public sealed class DiagnosticsNotificationPublisher : INotificationPublisher
         try
         {
             await _inner.Publish(handlers, cancellationToken).ConfigureAwait(false);
-            MediarqDiagnostics.Record("Publish", Stopwatch.GetElapsedTime(startTimestamp), succeeded: true);
+            var elapsed = Stopwatch.GetElapsedTime(startTimestamp);
+            MediarqDiagnostics.Record("Publish", elapsed, succeeded: true);
+            MediarqDiagnostics.RecordMessagingOperation(activity, "publish", "Publish", elapsed, batchMessageCount: handlers.Count);
             activity?.SetStatus(ActivityStatusCode.Ok);
         }
         catch (Exception exception)
         {
-            MediarqDiagnostics.Record("Publish", Stopwatch.GetElapsedTime(startTimestamp), succeeded: false);
+            var elapsed = Stopwatch.GetElapsedTime(startTimestamp);
+            MediarqDiagnostics.Record("Publish", elapsed, succeeded: false);
+            MediarqDiagnostics.RecordMessagingOperation(activity, "publish", "Publish", elapsed, batchMessageCount: handlers.Count, errorType: exception.GetType().FullName);
             activity?.SetStatus(ActivityStatusCode.Error, exception.Message);
             throw;
         }

--- a/src/Mediarq.Diagnostics/MediarqDiagnostics.cs
+++ b/src/Mediarq.Diagnostics/MediarqDiagnostics.cs
@@ -8,10 +8,23 @@ namespace Mediarq.Diagnostics;
 /// the metric instruments. Subscribe to the <see cref="SourceName"/> source/meter from OpenTelemetry
 /// or <c>System.Diagnostics</c> listeners.
 /// </summary>
+/// <remarks>
+/// Alongside the original Mediarq-specific instruments/tags (kept as-is — renaming them would break any
+/// dashboard already built against v1.x), every activity and the
+/// <see cref="MessagingOperationDuration"/> metric also carry the subset of the
+/// <see href="https://opentelemetry.io/docs/specs/semconv/messaging/">OpenTelemetry semantic conventions
+/// for messaging</see> that apply to an in-process mediator: <c>messaging.system</c>,
+/// <c>messaging.operation.type</c>, <c>messaging.destination.name</c>, <c>messaging.message.id</c>,
+/// <c>messaging.batch.message_count</c> and the general <c>error.type</c> attribute. See
+/// <c>docs/guides/observability-dashboard.md</c> for a ready-to-use dashboard built on these.
+/// </remarks>
 public static class MediarqDiagnostics
 {
     /// <summary>The name shared by the Mediarq <see cref="ActivitySource"/> and <see cref="System.Diagnostics.Metrics.Meter"/>.</summary>
     public const string SourceName = "Mediarq";
+
+    /// <summary>The <c>messaging.system</c> semantic convention value identifying Mediarq's in-process dispatch.</summary>
+    public const string MessagingSystem = "mediarq";
 
     /// <summary>The activity source that emits one activity per dispatched request.</summary>
     public static readonly ActivitySource ActivitySource = new(SourceName);
@@ -19,6 +32,13 @@ public static class MediarqDiagnostics
     private static readonly Meter Meter = new(SourceName);
     private static readonly Counter<long> RequestCounter = Meter.CreateCounter<long>("mediarq.requests.count", "{request}", "Number of requests dispatched through Mediarq.");
     private static readonly Histogram<double> RequestDuration = Meter.CreateHistogram<double>("mediarq.requests.duration", "ms", "Duration of Mediarq request handling.");
+
+    /// <summary>
+    /// The OpenTelemetry messaging semantic convention's <c>messaging.client.operation.duration</c>
+    /// histogram (seconds, per the spec), recorded alongside <c>mediarq.requests.duration</c>.
+    /// </summary>
+    private static readonly Histogram<double> MessagingOperationDuration = Meter.CreateHistogram<double>(
+        "messaging.client.operation.duration", "s", "Duration of a Mediarq dispatch, tagged per OpenTelemetry messaging semantic conventions.");
 
     internal static void Record(string requestName, TimeSpan elapsed, bool succeeded)
     {
@@ -30,5 +50,69 @@ public static class MediarqDiagnostics
 
         RequestCounter.Add(1, tags);
         RequestDuration.Record(elapsed.TotalMilliseconds, tags);
+    }
+
+    /// <summary>
+    /// Sets the OpenTelemetry messaging semantic convention tags on <paramref name="activity"/> and
+    /// records <see cref="MessagingOperationDuration"/>, in addition to (not instead of) the original
+    /// <c>mediarq.*</c> tags/metric a caller already set via <see cref="Record"/>.
+    /// </summary>
+    /// <param name="activity">The current activity, or <see langword="null"/> when nothing is sampling it.</param>
+    /// <param name="operationType">
+    /// The <c>messaging.operation.type</c> value: <c>"process"</c> for a request/query dispatch or a
+    /// stream, <c>"publish"</c> for a notification fan-out.
+    /// </param>
+    /// <param name="destinationName">The <c>messaging.destination.name</c> — the request/notification type name.</param>
+    /// <param name="elapsed">The measured duration.</param>
+    /// <param name="messageId">The <c>messaging.message.id</c>, when one is available (e.g. the request id).</param>
+    /// <param name="batchMessageCount">
+    /// The <c>messaging.batch.message_count</c>, for operations that fan out to more than one
+    /// destination (a notification's handler count, a stream's item count).
+    /// </param>
+    /// <param name="errorType">The <c>error.type</c> — the exception's type name, when the operation failed.</param>
+    internal static void RecordMessagingOperation(
+        Activity? activity,
+        string operationType,
+        string destinationName,
+        TimeSpan elapsed,
+        string? messageId = null,
+        long? batchMessageCount = null,
+        string? errorType = null)
+    {
+        if (activity is not null)
+        {
+            activity.SetTag("messaging.system", MessagingSystem);
+            activity.SetTag("messaging.operation.type", operationType);
+            activity.SetTag("messaging.destination.name", destinationName);
+
+            if (messageId is not null)
+            {
+                activity.SetTag("messaging.message.id", messageId);
+            }
+
+            if (batchMessageCount is not null)
+            {
+                activity.SetTag("messaging.batch.message_count", batchMessageCount.Value);
+            }
+
+            if (errorType is not null)
+            {
+                activity.SetTag("error.type", errorType);
+            }
+        }
+
+        var tags = new TagList
+        {
+            { "messaging.system", MessagingSystem },
+            { "messaging.operation.type", operationType },
+            { "messaging.destination.name", destinationName },
+        };
+
+        if (errorType is not null)
+        {
+            tags.Add("error.type", errorType);
+        }
+
+        MessagingOperationDuration.Record(elapsed.TotalSeconds, tags);
     }
 }

--- a/src/Mediarq.Diagnostics/PublicAPI.Unshipped.txt
+++ b/src/Mediarq.Diagnostics/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+const Mediarq.Diagnostics.MediarqDiagnostics.MessagingSystem = "mediarq" -> string!

--- a/src/Mediarq.Diagnostics/README.md
+++ b/src/Mediarq.Diagnostics/README.md
@@ -27,8 +27,15 @@ builder.Services.AddOpenTelemetry()
 
 Instruments: `mediarq.requests.count` and `mediarq.requests.duration`.
 
+Every activity and the `messaging.client.operation.duration` histogram also carry the subset of the
+[OpenTelemetry semantic conventions for messaging](https://opentelemetry.io/docs/specs/semconv/messaging/)
+that apply to an in-process mediator (`messaging.system`, `messaging.operation.type`,
+`messaging.destination.name`, `messaging.message.id`, `messaging.batch.message_count`, `error.type`) —
+additive, alongside the `mediarq.*` tags/metrics above, which are unchanged.
+
 ## Learn more
 
+[A ready-to-use observability dashboard](https://github.com/rouffou/mediarq/blob/main/docs/guides/observability-dashboard.md) ·
 [Wiring extensions](https://github.com/rouffou/mediarq/blob/main/docs/guides/wiring-extensions.md) ·
 [Full README](https://github.com/rouffou/mediarq#readme)
 

--- a/src/Mediarq.Diagnostics/StreamDiagnosticsBehavior.cs
+++ b/src/Mediarq.Diagnostics/StreamDiagnosticsBehavior.cs
@@ -40,11 +40,16 @@ public sealed class StreamDiagnosticsBehavior<TRequest, TResponse> : IStreamPipe
 
             succeeded = true;
         }
+        // No catch here: C# disallows `yield return` inside a try block that also has a catch clause, so
+        // (like the original code) failure is only observable via `succeeded` staying false, not the
+        // exception itself -- `error.type` is therefore never set for a stream, unlike Send/Publish.
         finally
         {
+            var elapsed = Stopwatch.GetElapsedTime(startTimestamp);
             activity?.SetTag("mediarq.stream.item_count", itemCount);
             activity?.SetStatus(succeeded ? ActivityStatusCode.Ok : ActivityStatusCode.Error);
-            MediarqDiagnostics.Record(RequestName, Stopwatch.GetElapsedTime(startTimestamp), succeeded);
+            MediarqDiagnostics.Record(RequestName, elapsed, succeeded);
+            MediarqDiagnostics.RecordMessagingOperation(activity, "process", RequestName, elapsed, batchMessageCount: itemCount);
         }
     }
 }


### PR DESCRIPTION
## Summary
- `Mediarq.Diagnostics` activities and a new `messaging.client.operation.duration` histogram (seconds, per the semconv spec) now also carry the subset of the OpenTelemetry semantic conventions for messaging that apply to an in-process mediator: `messaging.system` (`"mediarq"`), `messaging.operation.type` (`"process"` for Send/streams, `"publish"` for notifications), `messaging.destination.name`, `messaging.message.id`, `messaging.batch.message_count`, and the general `error.type` attribute.
- **Purely additive** (per explicit confirmation): the original `mediarq.*` tags/metrics are untouched, so a dashboard already built against the just-released v1.1.0 keeps working.
- New guide [`docs/guides/observability-dashboard.md`](docs/guides/observability-dashboard.md) with an importable Grafana dashboard (`docs/assets/observability-dashboard.json`) covering both the original instruments and the new semantic-convention attributes.
- Closes #33 (last remaining item in the v1.3 — Performance & observability milestone, alongside #32 already shipped).

## Test plan
- [x] `dotnet build Mediarq.sln` — 0 errors (pre-existing unrelated RS0016 warnings from already-merged code)
- [x] `dotnet test Mediarq.sln` — full suite green, including 3 new tests in `Mediarq.Diagnostics.Tests` (semconv tags on Send/Stream/Publish activities, `error.type` on failure, the new duration metric)
- [x] `docfx docs/docfx.json` builds clean and produces both the new guide page and the dashboard JSON asset in `_site`

🤖 Generated with [Claude Code](https://claude.com/claude-code)