### PR TITLE
feat(sourcegen): add MQ004, review incremental-caching correctness

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,9 @@ default. Override either via MSBuild:
 ```
 
 The generator also emits compile-time diagnostics: `MQ001` (multiple handlers for one request), `MQ002`
-(a command/query with no handler in the assembly), and `MQ003` (a validator whose target is neither a
-request nor a notification, so it can never run).
+(a command/query with no handler in the assembly), `MQ003` (a validator whose target is neither a
+request nor a notification, so it can never run), and `MQ004` (the reflection-based `AddMediarq(...)`
+called in a project that publishes with Native AOT).
 
 ## Commands & queries (with a result)
 

--- a/Tests/Mediarq.SourceGenerators.Tests/MediarqRegistrationGeneratorTests.cs
+++ b/Tests/Mediarq.SourceGenerators.Tests/MediarqRegistrationGeneratorTests.cs
@@ -33,12 +33,13 @@ public class MediarqRegistrationGeneratorTests
             new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
     }
 
-    private static (string GeneratedSource, ImmutableArray<Diagnostic> Diagnostics) Run(string source, string? accessibility = null, string? generatedNamespace = null)
+    private static (string GeneratedSource, ImmutableArray<Diagnostic> Diagnostics) Run(
+        string source, string? accessibility = null, string? generatedNamespace = null, bool? publishAot = null)
     {
         var compilation = CreateCompilation(source);
 
         AnalyzerConfigOptionsProvider? optionsProvider = null;
-        if (accessibility is not null || generatedNamespace is not null)
+        if (accessibility is not null || generatedNamespace is not null || publishAot is not null)
         {
             var globals = new Dictionary<string, string>();
             if (accessibility is not null)
@@ -49,6 +50,11 @@ public class MediarqRegistrationGeneratorTests
             if (generatedNamespace is not null)
             {
                 globals["build_property.MediarqGeneratedNamespace"] = generatedNamespace;
+            }
+
+            if (publishAot is not null)
+            {
+                globals["build_property.PublishAot"] = publishAot.Value ? "true" : "false";
             }
 
             optionsProvider = new TestOptionsProvider(globals);
@@ -392,6 +398,60 @@ public class MediarqRegistrationGeneratorTests
         var (_, diagnostics) = Run(source);
 
         diagnostics.Should().NotContain(d => d.Id == "MQ003");
+    }
+
+    private const string AddMediarqCallSite = """
+        using Mediarq.Extensions;
+        using Microsoft.Extensions.DependencyInjection;
+
+        namespace Demo;
+
+        public class Startup
+        {
+            public void Configure(IServiceCollection services)
+            {
+                services.AddMediarq(false);
+            }
+        }
+        """;
+
+    [Fact]
+    public void Reports_MQ004_When_AddMediarq_Called_In_An_Aot_Project()
+    {
+        var (_, diagnostics) = Run(AddMediarqCallSite, publishAot: true);
+
+        diagnostics.Should().Contain(d => d.Id == "MQ004");
+    }
+
+    [Fact]
+    public void Does_Not_Report_MQ004_When_Project_Is_Not_Aot()
+    {
+        var (_, diagnostics) = Run(AddMediarqCallSite, publishAot: false);
+
+        diagnostics.Should().NotContain(d => d.Id == "MQ004");
+    }
+
+    [Fact]
+    public void Does_Not_Report_MQ004_When_Not_Calling_AddMediarq()
+    {
+        const string source = """
+            using Mediarq.Extensions;
+            using Microsoft.Extensions.DependencyInjection;
+
+            namespace Demo;
+
+            public class Startup
+            {
+                public void Configure(IServiceCollection services)
+                {
+                    services.AddMediarqCore();
+                }
+            }
+            """;
+
+        var (_, diagnostics) = Run(source, publishAot: true);
+
+        diagnostics.Should().NotContain(d => d.Id == "MQ004");
     }
 
     [Fact]

--- a/docs/guides/native-aot.md
+++ b/docs/guides/native-aot.md
@@ -20,6 +20,10 @@ handler, behavior and validator it finds at compile time, and pre-populates a `M
 with strongly-typed dispatch wrappers — so `Send`, `Publish` and `CreateStream` never need
 `Activator.CreateInstance` or `MakeGenericType` at runtime.
 
+If your project sets `PublishAot`/`IsAotCompatible` but still calls the reflection-based `AddMediarq(...)`
+anywhere, the generator reports **`MQ004`** (warning) at that call site as a nudge to switch to
+`AddMediarqCore()` + `AddMediarqHandlers()`.
+
 ## Publishing for Native AOT
 
 ```bash

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -120,6 +120,11 @@ annotated `[RequiresUnreferencedCode]`). For caching/idempotency on AOT, provide
 `IMediarqCacheSerializer`. A native publish also needs the platform C/C++ build tools on `PATH`. See
 [Native AOT & trimming](native-aot.md).
 
+### Build warning `MQ004` — reflection-based `AddMediarq` used in an AOT-published project
+Your project sets `PublishAot`/`IsAotCompatible`, but a call site still uses the reflection-based
+`AddMediarq(...)` scan. Switch it to `AddMediarqCore().AddMediarqHandlers()` — see
+[Native AOT & trimming](native-aot.md).
+
 ## Still stuck?
 
 Compare your wiring against the runnable

--- a/src/Mediarq.Core/build/Mediarq.Core.props
+++ b/src/Mediarq.Core/build/Mediarq.Core.props
@@ -3,9 +3,14 @@
        - MediarqGeneratedAccessibility: set to "public" to make the generated AddMediarqHandlers()
          public instead of internal (so it can be called from another assembly).
        - MediarqGeneratedNamespace: the namespace of the generated registration class
-         (default: Mediarq.Extensions). -->
+         (default: Mediarq.Extensions).
+       - PublishAot / IsAotCompatible: standard MSBuild properties, exposed here (not visible to
+         generators by default) so the generator can report MQ004 when the reflection-based
+         AddMediarq(...) is called in a project that opts into Native AOT. -->
   <ItemGroup>
     <CompilerVisibleProperty Include="MediarqGeneratedAccessibility" />
     <CompilerVisibleProperty Include="MediarqGeneratedNamespace" />
+    <CompilerVisibleProperty Include="PublishAot" />
+    <CompilerVisibleProperty Include="IsAotCompatible" />
   </ItemGroup>
 </Project>

--- a/src/Mediarq.SourceGenerators/MediarqRegistrationGenerator.cs
+++ b/src/Mediarq.SourceGenerators/MediarqRegistrationGenerator.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Mediarq.SourceGenerators;
@@ -47,6 +48,14 @@ public sealed class MediarqRegistrationGenerator : IIncrementalGenerator
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true);
 
+    private static readonly DiagnosticDescriptor ReflectionBasedRegistrationInAotProject = new(
+        id: "MQ004",
+        title: "Reflection-based AddMediarq used in an AOT-published project",
+        messageFormat: "This project publishes with Native AOT (PublishAot/IsAotCompatible), but calls the reflection-based AddMediarq(...), which is annotated [RequiresUnreferencedCode]/[RequiresDynamicCode] and not trim/AOT safe. Prefer AddMediarqCore() + the generated AddMediarqHandlers().",
+        category: "Mediarq",
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
     /// <inheritdoc />
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
@@ -77,6 +86,61 @@ public sealed class MediarqRegistrationGenerator : IIncrementalGenerator
 
         context.RegisterSourceOutput(registrations.Combine(options),
             static (spc, pair) => Emit(spc, pair.Left, pair.Right.Left, pair.Right.Right));
+
+        // MQ004: this project publishes with Native AOT (PublishAot or IsAotCompatible), but calls the
+        // reflection-based AddMediarq(...) instead of AddMediarqCore() + this generator's own
+        // AddMediarqHandlers(). Both are ordinary MSBuild properties, not visible to generators unless
+        // explicitly exposed -- see src/Mediarq.Core/build/Mediarq.Core.props.
+        var isAotProject = context.AnalyzerConfigOptionsProvider.Select(static (provider, _) =>
+            IsTrue(provider, "build_property.PublishAot") || IsTrue(provider, "build_property.IsAotCompatible"));
+
+        var reflectionRegistrationCalls = context.SyntaxProvider
+            .CreateSyntaxProvider(
+                predicate: static (node, _) => node is InvocationExpressionSyntax
+                {
+                    Expression: MemberAccessExpressionSyntax { Name.Identifier.ValueText: "AddMediarq" },
+                },
+                transform: static (ctx, ct) => TransformAddMediarqCall(ctx, ct))
+            .Where(static location => location is not null)
+            .Collect();
+
+        context.RegisterSourceOutput(reflectionRegistrationCalls.Combine(isAotProject), static (spc, pair) =>
+        {
+            if (!pair.Right)
+            {
+                return;
+            }
+
+            foreach (var location in pair.Left)
+            {
+                spc.ReportDiagnostic(Diagnostic.Create(ReflectionBasedRegistrationInAotProject, location));
+            }
+        });
+    }
+
+    private static bool IsTrue(AnalyzerConfigOptionsProvider provider, string key) =>
+        provider.GlobalOptions.TryGetValue(key, out var value) && string.Equals(value, "true", System.StringComparison.OrdinalIgnoreCase);
+
+    // Resolves the invoked method's symbol to make sure this is really Mediarq.Extensions'
+    // ServiceCollectionExtensions.AddMediarq(...) (the reflection-based, [RequiresUnreferencedCode]
+    // scan) and not some unrelated method that merely happens to share the name.
+    private static Location? TransformAddMediarqCall(GeneratorSyntaxContext ctx, CancellationToken cancellationToken)
+    {
+        var invocation = (InvocationExpressionSyntax)ctx.Node;
+        if (ctx.SemanticModel.GetSymbolInfo(invocation, cancellationToken).Symbol is not IMethodSymbol method)
+        {
+            return null;
+        }
+
+        var containingType = method.ContainingType;
+        if (method.Name != "AddMediarq" ||
+            containingType?.Name != "ServiceCollectionExtensions" ||
+            containingType.ContainingNamespace?.ToDisplayString() != "Mediarq.Extensions")
+        {
+            return null;
+        }
+
+        return invocation.GetLocation();
     }
 
     private static EquatableArray<HandlerRegistration> Transform(GeneratorSyntaxContext ctx, CancellationToken cancellationToken)


### PR DESCRIPTION
## Summary
- New `MQ004` (warning): the generator now flags a call to the reflection-based `AddMediarq(...)` in a project that sets `PublishAot`/`IsAotCompatible`, nudging toward `AddMediarqCore()` + `AddMediarqHandlers()`.
- `PublishAot`/`IsAotCompatible` are ordinary MSBuild properties, not visible to source generators by default — exposed via `CompilerVisibleProperty` in `src/Mediarq.Core/build/Mediarq.Core.props`, alongside the existing Mediarq-specific generator options.
- Reviewed the "faster incremental generation" half of this issue: `EquatableArray<HandlerRegistration>` already gives every pipeline stage value-based equality (the standard fix for the classic incremental-generator caching pitfall) — confirmed already correct, no further change needed there.
- Closes #34 — **the last open issue in the v1.3 — Performance & observability milestone.**

## Test plan
- [x] `dotnet build Mediarq.sln` — 0 warnings, 0 errors
- [x] `dotnet test Mediarq.sln` — full suite green, including 3 new tests in `Mediarq.SourceGenerators.Tests` (MQ004 fires for `AddMediarq` in an AOT project, doesn't fire when not AOT, doesn't fire for `AddMediarqCore`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)