### PR TITLE
feat(ci): run the published Native AOT binary on a win/linux matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,18 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   aot:
-    name: Native AOT publish (reflection-free path)
-    runs-on: ubuntu-latest
+    name: Native AOT (${{ matrix.rid }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            rid: linux-x64
+            executable: ./aot-publish/Mediarq.AotSample
+          - os: windows-latest
+            rid: win-x64
+            executable: ./aot-publish/Mediarq.AotSample.exe
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
 
@@ -56,10 +66,27 @@ jobs:
         with:
           dotnet-version: 10.0.x
 
-      - name: Install Native AOT prerequisites
+      - name: Install Native AOT prerequisites (Linux)
+        if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y clang zlib1g-dev
 
       # The sample uses AddMediarqCore() + the generated AddMediarqHandlers() and is built with
       # TreatWarningsAsErrors, so any trimming/AOT (IL****) warning fails the job.
       - name: Publish AOT sample
-        run: dotnet publish Samples/Mediarq.AotSample/Mediarq.AotSample.csproj -r linux-x64 -c Release
+        run: dotnet publish Samples/Mediarq.AotSample/Mediarq.AotSample.csproj -r ${{ matrix.rid }} -c Release -o ./aot-publish
+
+      # Publishing cleanly isn't proof the binary actually works: trimming can silently remove a member
+      # only reached at runtime (e.g. through an interface implemented via reflection-invisible paths).
+      # Run the real native executable and compare its output byte-for-byte against what the same
+      # source produces normally, so a trimming regression that publish-time analysis misses still fails CI.
+      - name: Run the published binary and verify its output
+        shell: bash
+        run: |
+          actual="$(${{ matrix.executable }})"
+          echo "$actual"
+          expected=$'command    : success=True, value=aot\nquery      : Hello, Ada!\nvalidation : failure=True (Validation.General)\nstream     : 3 2 1 \nnotified   : 42\ndone'
+          if [ "$actual" != "$expected" ]; then
+            echo "::error::Native AOT binary output does not match the expected output"
+            diff <(printf '%s\n' "$expected") <(printf '%s\n' "$actual")
+            exit 1
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,10 @@ jobs:
       - name: Run the published binary and verify its output
         shell: bash
         run: |
-          actual="$(${{ matrix.executable }})"
+          # tr -d '\r': on Windows, Console.WriteLine emits CRLF, and command substitution only
+          # strips trailing newlines, not embedded \r -- without this every line compares unequal
+          # even though it looks identical once printed.
+          actual="$(${{ matrix.executable }} | tr -d '\r')"
           echo "$actual"
           expected=$'command    : success=True, value=aot\nquery      : Hello, Ada!\nvalidation : failure=True (Validation.General)\nstream     : 3 2 1 \nnotified   : 42\ndone'
           if [ "$actual" != "$expected" ]; then

--- a/docs/guides/native-aot.md
+++ b/docs/guides/native-aot.md
@@ -59,8 +59,11 @@ default. Override either:
 
 ## Verifying
 
-The repository ships an AOT smoke sample under `Samples/Mediarq.AotSample`, and a CI job publishes it
-with `PublishAot=true` to catch regressions. Run a trim/AOT analysis on your app with:
+The repository ships an AOT smoke sample under `Samples/Mediarq.AotSample`. The `aot` CI job publishes
+it with `PublishAot=true` on both `linux-x64` and `win-x64`, **and runs the resulting native binary**,
+comparing its output byte-for-byte against what the same source produces normally — publishing cleanly
+isn't proof the binary actually works, since trimming can silently remove a member only reached at
+runtime. Run a trim/AOT analysis on your own app with:
 
 ```bash
 dotnet publish -c Release -r <rid> /p:PublishAot=true


### PR DESCRIPTION
## Summary
- The `aot` CI job previously only ran `dotnet publish ... -r linux-x64 -c Release` — proof the trim/AOT analysis is clean, not proof the resulting binary actually works.
- Now a `linux-x64` (ubuntu-latest) / `win-x64` (windows-latest) matrix, and after publishing, **executes** the native binary and compares its stdout byte-for-byte against what the same source produces via a normal `dotnet run` — catches a trimming regression that only manifests at runtime, which publish-time analysis can't.
- Closes #90.

## Test plan
- [x] `dotnet build Mediarq.sln` — 0 errors
- [x] Captured the exact expected output via `dotnet run -c Release --project Samples/Mediarq.AotSample` locally and used it verbatim in the workflow's comparison
- [ ] Could not fully verify the `win-x64` AOT publish+execute locally (missing `vswhere`/VS native toolchain in this sandbox) — the actual CI run on `windows-latest` is the real test; will watch it and fix any issues it surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)