### PR TITLE
feat(ci): add Stryker.NET mutation testing on Mediarq.Core

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-stryker": {
+      "version": "4.16.0",
+      "commands": [
+        "dotnet-stryker"
+      ],
+      "rollForward": false
+    }
+  }
+}

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -1,0 +1,41 @@
+name: Mutation testing
+
+# Stryker.NET mutation testing on Mediarq.Core (the "core lib"), scored against Tests/Mediarq.Tests.
+# A full run mutates every branch/expression in the core library and re-runs the whole suite per
+# surviving mutant candidate — far too slow to run on every push/PR, so this is scheduled weekly plus
+# an on-demand workflow_dispatch. Report-only: thresholds.break is 0 in stryker-config.json, so a low
+# score never fails the job — this is a signal to look for test gaps, not a merge gate.
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Weekly, Mondays 04:17 UTC (offset from CodeQL's Monday 03:27 scan to avoid runner contention).
+    - cron: '17 4 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  stryker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Restore .NET tools
+        run: dotnet tool restore
+
+      - name: Run Stryker mutation testing on Mediarq.Core
+        working-directory: Tests/Mediarq.Tests
+        run: dotnet stryker
+
+      - name: Upload mutation report
+        uses: actions/upload-artifact@v4
+        with:
+          name: mutation-report
+          path: Tests/Mediarq.Tests/StrykerOutput/**/reports/*
+          if-no-files-found: warn

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,9 @@ artifacts/
 # BenchmarkDotNet output
 BenchmarkDotNet.Artifacts/
 
+# Stryker.NET mutation testing output
+StrykerOutput/
+
 # ASP.NET Scaffolding
 ScaffoldingReadMe.txt
 

--- a/Tests/Mediarq.Tests/stryker-config.json
+++ b/Tests/Mediarq.Tests/stryker-config.json
@@ -1,0 +1,13 @@
+{
+  "stryker-config": {
+    "project": "Mediarq.Core.csproj",
+    "mutation-level": "Standard",
+    "reporters": ["html", "progress", "json"],
+    "thresholds": { "high": 80, "low": 60, "break": 0 },
+    "mutate": [
+      "**/*.cs",
+      "!**/obj/**/*.cs",
+      "!**/bin/**/*.cs"
+    ]
+  }
+}

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -133,3 +133,21 @@ An in-memory EF Core provider (as in the WebApi sample) keeps these tests fast a
 | Integration (WebApplicationFactory) | routing, `Result` → HTTP, idempotency, the real wiring | slower |
 
 The library's own test suite (`Tests/`) is a worked reference for all three.
+
+## Mutation testing (Mediarq.Core)
+
+[Stryker.NET](https://stryker-mutator.io/docs/stryker-net/introduction/) mutates `Mediarq.Core`'s code
+(flips a `>` to `>=`, removes a condition, ...) and re-runs `Tests/Mediarq.Tests` against each mutant: a
+"survived" mutant is a change the suite didn't notice — a test gap. Config lives at
+`Tests/Mediarq.Tests/stryker-config.json`; run it locally with:
+
+```bash
+dotnet tool restore
+cd Tests/Mediarq.Tests
+dotnet stryker
+```
+
+A full run mutates the whole library and re-runs the suite per surviving candidate, so it's not part of
+the per-PR `ci.yml` — it runs weekly and on demand via `.github/workflows/mutation-testing.yml`, which
+uploads the HTML/JSON report as a build artifact. `thresholds.break` is `0` in the config, so a low score
+never fails the job: treat the report as a prompt to add tests where mutants survive, not a merge gate.


### PR DESCRIPTION
## Summary
- New `.config/dotnet-tools.json` (`dotnet-stryker` local tool) and `Tests/Mediarq.Tests/stryker-config.json`, targeting `Mediarq.Core`, scored against `Tests/Mediarq.Tests` (176 tests).
- New `.github/workflows/mutation-testing.yml`: weekly + `workflow_dispatch`, uploads the HTML/JSON report as a build artifact. **Report-only** (`thresholds.break: 0`) — a full mutation run re-runs the whole suite per surviving mutant candidate, far too slow for every PR, and consistent with this repo's "report, don't gate" approach for expensive/noisy CI signals (see the `benchmarks` workflow).
- New "Mutation testing" section in `docs/guides/testing.md`.
- Closes #93.

## Test plan
- [x] `dotnet build Mediarq.sln` — 0 warnings, 0 errors
- [x] Verified locally end-to-end: `dotnet tool restore` + `dotnet stryker` (scoped to a single file via `-m` for a fast sanity check) — config parses correctly, project discovery/build/initial test run/mutant generation/HTML+JSON report all work
- [ ] A full unscoped run (mutating all of `Mediarq.Core`) hasn't been timed/run end-to-end locally — the actual scheduled/dispatched CI run will be the first real full-scope execution; will check its duration and output once it fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)