### PR TITLE
fix(ci): publish MediatRCompat, Idempotency.EntityFrameworkCore, Analyzers to NuGet

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,9 @@ jobs:
           dotnet pack src/Mediarq.EntityFrameworkCore/Mediarq.EntityFrameworkCore.csproj --no-build -c Release -p:Version=${{ steps.version.outputs.version }} -o ./artifacts
           dotnet pack src/Mediarq.Outbox/Mediarq.Outbox.csproj --no-build -c Release -p:Version=${{ steps.version.outputs.version }} -o ./artifacts
           dotnet pack src/Mediarq.Polly/Mediarq.Polly.csproj --no-build -c Release -p:Version=${{ steps.version.outputs.version }} -o ./artifacts
+          dotnet pack src/Mediarq.MediatRCompat/Mediarq.MediatRCompat.csproj --no-build -c Release -p:Version=${{ steps.version.outputs.version }} -o ./artifacts
+          dotnet pack src/Mediarq.Idempotency.EntityFrameworkCore/Mediarq.Idempotency.EntityFrameworkCore.csproj --no-build -c Release -p:Version=${{ steps.version.outputs.version }} -o ./artifacts
+          dotnet pack src/Mediarq.Analyzers/Mediarq.Analyzers.csproj --no-build -c Release -p:Version=${{ steps.version.outputs.version }} -o ./artifacts
 
       - name: NuGet login (trusted publishing)
         id: login


### PR DESCRIPTION
## Summary
- `Mediarq.MediatRCompat`, `Mediarq.Idempotency.EntityFrameworkCore`, and `Mediarq.Analyzers` all declare a `PackageId` but were missing from `release.yml`'s pack step, so they were never actually published to NuGet (MediatRCompat has been in the repo since v1.1.0).
- Adds the missing `dotnet pack` lines for all three.

## Test plan
- [x] `dotnet build -c Release` succeeds
- [x] Local `dotnet pack -p:Version=1.3.0` verified for all three projects, producing valid `.nupkg` files