### PR TITLE
feat(templates): add mediarq-webapi dotnet new project template

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,18 @@ need to keep dependencies minimal.
 
 ### Scaffolding (`dotnet new`)
 
-Install the templates and scaffold a feature (a command, its handler and a validator) in one command:
+Install the templates once, then scaffold either a feature or a full solution:
 
 ```bash
 dotnet new install Mediarq.Templates
+
+# a command, its handler and a validator
 dotnet new mediarq-feature -n CreateUser --namespace MyApp.Users
+
+# a runnable ASP.NET Core Web API wired with Mediarq: commands, queries, a FluentValidation
+# validator, minimal-API endpoints mapping Result to HTTP, and request logging — all working
+# out of the box against an in-memory store
+dotnet new mediarq-webapi -n MyApi -o MyApi
 ```
 
 ## Getting started

--- a/docs/guides/your-first-app.md
+++ b/docs/guides/your-first-app.md
@@ -5,6 +5,7 @@ command, a query, validation and a notification. ~10 minutes. Copy each block in
 
 > Prefer to read finished code? See [Samples/Mediarq.Samples.WebApi](https://github.com/rouffou/mediarq/tree/main/Samples/Mediarq.Samples.WebApi).
 > Want a console instead of a web app? See [Samples/Mediarq.Samples.Quickstart](https://github.com/rouffou/mediarq/tree/main/Samples/Mediarq.Samples.Quickstart).
+> Want this scaffolded for you instead of typed by hand? `dotnet new install Mediarq.Templates && dotnet new mediarq-webapi -n TodoApi -o TodoApi` generates a runnable project with the same shape (commands, queries, a validator, minimal-API endpoints) — this guide walks through building it from scratch to explain each piece.
 
 ## 1. Create the project
 

--- a/templates/Mediarq.Templates.csproj
+++ b/templates/Mediarq.Templates.csproj
@@ -6,7 +6,7 @@
     <Version>1.0.0</Version>
     <Title>Mediarq templates</Title>
     <Authors>Nicolas Rouffart</Authors>
-    <Description>dotnet new templates for Mediarq. Includes 'mediarq-feature' which scaffolds a command, its handler and a validator.</Description>
+    <Description>dotnet new templates for Mediarq. Includes 'mediarq-feature' (scaffolds a command, its handler and a validator) and 'mediarq-webapi' (a full CQRS ASP.NET Core Web API solution wired with Mediarq).</Description>
     <PackageTags>dotnet-new;templates;mediarq;cqrs;mediator</PackageTags>
     <PackageProjectUrl>https://github.com/rouffou/mediarq</PackageProjectUrl>
     <RepositoryUrl>https://github.com/rouffou/mediarq</RepositoryUrl>
@@ -27,6 +27,7 @@
   <ItemGroup>
     <!-- Ship the template content; never compile it as part of this project. -->
     <Content Include="feature\**\*" Exclude="feature\**\bin\**;feature\**\obj\**" />
+    <Content Include="webapi\**\*" Exclude="webapi\**\bin\**;webapi\**\obj\**" />
     <Compile Remove="**\*" />
   </ItemGroup>
 

--- a/templates/webapi/.template.config/template.json
+++ b/templates/webapi/.template.config/template.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "Nicolas Rouffart",
+  "classifications": [ "Mediarq", "CQRS", "Web", "WebAPI" ],
+  "identity": "Mediarq.WebApi.CSharp",
+  "name": "Mediarq CQRS Web API",
+  "shortName": "mediarq-webapi",
+  "tags": {
+    "language": "C#",
+    "type": "project"
+  },
+  "sourceName": "Mediarq.WebApiTemplate1",
+  "preferNameDirectory": true,
+  "symbols": {
+    "Framework": {
+      "type": "parameter",
+      "datatype": "choice",
+      "choices": [
+        { "choice": "net8.0", "description": "Target net8.0" },
+        { "choice": "net9.0", "description": "Target net9.0" },
+        { "choice": "net10.0", "description": "Target net10.0" }
+      ],
+      "replaces": "net10.0",
+      "defaultValue": "net10.0",
+      "description": "The target framework."
+    }
+  }
+}

--- a/templates/webapi/Features/Todos/CompleteTodo.cs
+++ b/templates/webapi/Features/Todos/CompleteTodo.cs
@@ -1,0 +1,21 @@
+using Mediarq.Core.Common.Requests.Command;
+using Mediarq.Core.Common.Results;
+
+namespace Mediarq.WebApiTemplate1.Features.Todos;
+
+public sealed record CompleteTodoCommand(Guid Id) : ICommand<Result>;
+
+public sealed class CompleteTodoHandler(ITodoStore store) : ICommandHandler<CompleteTodoCommand, Result>
+{
+    public Task<Result> Handle(CompleteTodoCommand request, CancellationToken cancellationToken = default)
+    {
+        var todo = store.Get(request.Id);
+        if (todo is null)
+        {
+            return Task.FromResult(Result.Failure(ResultError.NotFound("Todo.NotFound", $"Todo {request.Id} was not found.")));
+        }
+
+        todo.IsComplete = true;
+        return Task.FromResult(Result.Success());
+    }
+}

--- a/templates/webapi/Features/Todos/CreateTodo.cs
+++ b/templates/webapi/Features/Todos/CreateTodo.cs
@@ -1,0 +1,25 @@
+using FluentValidation;
+using Mediarq.Core.Common.Requests.Command;
+using Mediarq.Core.Common.Results;
+
+namespace Mediarq.WebApiTemplate1.Features.Todos;
+
+public sealed record CreateTodoCommand(string Title) : ICommand<Result<Guid>>;
+
+public sealed class CreateTodoHandler(ITodoStore store) : ICommandHandler<CreateTodoCommand, Result<Guid>>
+{
+    public Task<Result<Guid>> Handle(CreateTodoCommand request, CancellationToken cancellationToken = default)
+    {
+        var todo = store.Add(new Todo { Id = Guid.NewGuid(), Title = request.Title });
+        return Task.FromResult(Result.Success(todo.Id));
+    }
+}
+
+/// <summary>FluentValidation validator, bridged into the Mediarq pipeline by AddMediarqFluentValidation().</summary>
+public sealed class CreateTodoCommandValidator : AbstractValidator<CreateTodoCommand>
+{
+    public CreateTodoCommandValidator()
+    {
+        RuleFor(x => x.Title).NotEmpty().MaximumLength(200);
+    }
+}

--- a/templates/webapi/Features/Todos/DeleteTodo.cs
+++ b/templates/webapi/Features/Todos/DeleteTodo.cs
@@ -1,0 +1,18 @@
+using Mediarq.Core.Common.Requests.Command;
+using Mediarq.Core.Common.Results;
+
+namespace Mediarq.WebApiTemplate1.Features.Todos;
+
+public sealed record DeleteTodoCommand(Guid Id) : ICommand<Result>;
+
+public sealed class DeleteTodoHandler(ITodoStore store) : ICommandHandler<DeleteTodoCommand, Result>
+{
+    public Task<Result> Handle(DeleteTodoCommand request, CancellationToken cancellationToken = default)
+    {
+        var result = store.Remove(request.Id)
+            ? Result.Success()
+            : Result.Failure(ResultError.NotFound("Todo.NotFound", $"Todo {request.Id} was not found."));
+
+        return Task.FromResult(result);
+    }
+}

--- a/templates/webapi/Features/Todos/GetTodoById.cs
+++ b/templates/webapi/Features/Todos/GetTodoById.cs
@@ -1,0 +1,25 @@
+using Mediarq.Core.Common.Requests.Query;
+using Mediarq.Core.Common.Results;
+
+namespace Mediarq.WebApiTemplate1.Features.Todos;
+
+public sealed record TodoDto(Guid Id, string Title, bool IsComplete)
+{
+    public static TodoDto From(Todo todo) => new(todo.Id, todo.Title, todo.IsComplete);
+}
+
+public sealed record GetTodoByIdQuery(Guid Id) : IQuery<Result<TodoDto>>;
+
+public sealed class GetTodoByIdHandler(ITodoStore store) : IQueryHandler<GetTodoByIdQuery, Result<TodoDto>>
+{
+    public Task<Result<TodoDto>> Handle(GetTodoByIdQuery request, CancellationToken cancellationToken = default)
+    {
+        var todo = store.Get(request.Id);
+
+        var result = todo is null
+            ? Result.Failure<TodoDto>(ResultError.NotFound("Todo.NotFound", $"Todo {request.Id} was not found."))
+            : Result.Success(TodoDto.From(todo));
+
+        return Task.FromResult(result);
+    }
+}

--- a/templates/webapi/Features/Todos/ListTodos.cs
+++ b/templates/webapi/Features/Todos/ListTodos.cs
@@ -1,0 +1,15 @@
+using Mediarq.Core.Common.Requests.Query;
+using Mediarq.Core.Common.Results;
+
+namespace Mediarq.WebApiTemplate1.Features.Todos;
+
+public sealed record ListTodosQuery : IQuery<Result<IReadOnlyList<TodoDto>>>;
+
+public sealed class ListTodosHandler(ITodoStore store) : IQueryHandler<ListTodosQuery, Result<IReadOnlyList<TodoDto>>>
+{
+    public Task<Result<IReadOnlyList<TodoDto>>> Handle(ListTodosQuery request, CancellationToken cancellationToken = default)
+    {
+        IReadOnlyList<TodoDto> todos = store.GetAll().Select(TodoDto.From).ToList();
+        return Task.FromResult(Result.Success(todos));
+    }
+}

--- a/templates/webapi/Features/Todos/Todo.cs
+++ b/templates/webapi/Features/Todos/Todo.cs
@@ -1,0 +1,36 @@
+using System.Collections.Concurrent;
+
+namespace Mediarq.WebApiTemplate1.Features.Todos;
+
+public sealed class Todo
+{
+    public required Guid Id { get; init; }
+    public required string Title { get; set; }
+    public bool IsComplete { get; set; }
+}
+
+public interface ITodoStore
+{
+    Todo Add(Todo todo);
+    Todo? Get(Guid id);
+    IReadOnlyList<Todo> GetAll();
+    bool Remove(Guid id);
+}
+
+/// <summary>In-memory, process-lifetime store. Replace with a real persistence layer in production.</summary>
+public sealed class InMemoryTodoStore : ITodoStore
+{
+    private readonly ConcurrentDictionary<Guid, Todo> _todos = new();
+
+    public Todo Add(Todo todo)
+    {
+        _todos[todo.Id] = todo;
+        return todo;
+    }
+
+    public Todo? Get(Guid id) => _todos.GetValueOrDefault(id);
+
+    public IReadOnlyList<Todo> GetAll() => _todos.Values.OrderBy(t => t.Title).ToList();
+
+    public bool Remove(Guid id) => _todos.TryRemove(id, out _);
+}

--- a/templates/webapi/Features/Todos/TodoEndpoints.cs
+++ b/templates/webapi/Features/Todos/TodoEndpoints.cs
@@ -1,0 +1,35 @@
+using Mediarq.AspNetCore;
+using Mediarq.Core.Mediators;
+
+namespace Mediarq.WebApiTemplate1.Features.Todos;
+
+/// <summary>
+/// Minimal-API endpoints. Each one dispatches a Mediarq request and maps the <c>Result</c> to an HTTP
+/// response via <c>ToHttpResultAsync()</c> — success becomes 200/204, failure becomes RFC 7807
+/// ProblemDetails with a status derived from the <c>ResultError</c> category.
+/// </summary>
+public static class TodoEndpoints
+{
+    public static IEndpointRouteBuilder MapTodoEndpoints(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/todos").WithTags("Todos");
+
+        // Create — runs the FluentValidation validator via the pipeline before the handler executes.
+        group.MapPost("/", (CreateTodoCommand command, ISender sender)
+            => sender.Send(command).ToHttpResultAsync());
+
+        group.MapGet("/{id:guid}", (Guid id, ISender sender)
+            => sender.Send(new GetTodoByIdQuery(id)).ToHttpResultAsync());
+
+        group.MapGet("/", (ISender sender)
+            => sender.Send(new ListTodosQuery()).ToHttpResultAsync());
+
+        group.MapPost("/{id:guid}/complete", (Guid id, ISender sender)
+            => sender.Send(new CompleteTodoCommand(id)).ToHttpResultAsync());
+
+        group.MapDelete("/{id:guid}", (Guid id, ISender sender)
+            => sender.Send(new DeleteTodoCommand(id)).ToHttpResultAsync());
+
+        return app;
+    }
+}

--- a/templates/webapi/Mediarq.WebApiTemplate1.csproj
+++ b/templates/webapi/Mediarq.WebApiTemplate1.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Floating minimum so scaffolded projects pick up newer Mediarq releases without editing this file. -->
+    <PackageReference Include="Mediarq" Version="[1.3.0,)" />
+    <!-- NU1903: Microsoft.AspNetCore.OpenApi 10.0.10 transitively pulls a Microsoft.OpenApi with a known
+         advisory (GHSA-v5pm-xwqc-g5wc). Pinning Microsoft.OpenApi past it breaks the package's source
+         generator (breaking API change upstream) — left as-is until Microsoft ships a fixed 10.x. -->
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.10" />
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.11.0" />
+  </ItemGroup>
+
+</Project>

--- a/templates/webapi/Program.cs
+++ b/templates/webapi/Program.cs
@@ -1,0 +1,41 @@
+using FluentValidation;
+using Mediarq.Extensions;
+using Mediarq.FluentValidation;
+using Mediarq.WebApiTemplate1.Features.Todos;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// --------------------------------------------------------------------------------------------------
+// Infrastructure the extensions build on. Swap InMemoryTodoStore for a real persistence layer
+// (e.g. Mediarq.EntityFrameworkCore) when you outgrow it.
+// --------------------------------------------------------------------------------------------------
+builder.Services.AddSingleton<ITodoStore, InMemoryTodoStore>();
+builder.Services.AddHttpContextAccessor(); // required by HttpUserContext (isHttp: true)
+
+// FluentValidation validators discovered for the FluentValidation adapter.
+builder.Services.AddValidatorsFromAssemblyContaining<Program>();
+
+// Validation adapter BEFORE AddMediarq so the scan wires the ValidationBehavior (open-generic IValidator<>).
+builder.Services.AddMediarqFluentValidation();
+
+// Mediarq core. Scans this assembly for handlers, behaviors and validators.
+// (For trimming / Native AOT, swap for: AddMediarqCore(isHttp: true).AddMediarqHandlers().)
+builder.Services.AddMediarq(isHttp: true, typeof(Program).Assembly)
+    .AddMediarqRequestLogging();
+
+builder.Services.AddOpenApi();
+
+var app = builder.Build();
+
+if (app.Environment.IsDevelopment())
+{
+    app.MapOpenApi();
+}
+
+app.MapTodoEndpoints();
+app.MapGet("/", () => Results.Redirect("/openapi/v1.json"));
+
+app.Run();
+
+// Exposed so the test host / WebApplicationFactory can reference the entry point.
+public partial class Program;

--- a/templates/webapi/Properties/launchSettings.json
+++ b/templates/webapi/Properties/launchSettings.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "todos",
+      "applicationUrl": "http://localhost:5205",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "todos",
+      "applicationUrl": "https://localhost:7205;http://localhost:5205",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/templates/webapi/appsettings.Development.json
+++ b/templates/webapi/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/templates/webapi/appsettings.json
+++ b/templates/webapi/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
## Summary
- New `mediarq-webapi` project template (`dotnet new mediarq-webapi -n MyApi -o MyApi`), shipped alongside the existing `mediarq-feature` item template in the `Mediarq.Templates` package.
- Scaffolds a runnable ASP.NET Core Web API wired with the `Mediarq` meta-package: a CQRS `Todos` feature (`CreateTodoCommand`, `GetTodoByIdQuery`, `ListTodosQuery`, `CompleteTodoCommand`, `DeleteTodoCommand`), a FluentValidation validator wired through the pipeline, minimal-API endpoints mapping `Result`/`Result<T>` to HTTP via `ToHttpResultAsync()`, and `AddMediarqRequestLogging()` — all against an in-memory store, zero external dependencies.
- Updated `README.md` and `docs/guides/your-first-app.md` to point at the new template.

Closes #38.

## Test plan
- [x] `dotnet new install ./templates` then `dotnet new mediarq-webapi -n TestApi -o TestApi` — placeholder namespace/filenames correctly substituted
- [x] `dotnet build` succeeds on the generated project
- [x] Ran the generated API and exercised every endpoint manually: create (+ 400 on invalid input via FluentValidation), list, get-by-id, complete (204), get-by-id after complete, get on missing id (404 ProblemDetails), delete (204), list after delete — all behaved as expected, request-logging behavior confirmed in the console output