### PR TITLE
feat(analyzers): add MQ201 pipeline-behavior-never-calls-next rule

### DIFF
--- a/Tests/Mediarq.Analyzers.Tests/PipelineBehaviorNextAnalyzerTests.cs
+++ b/Tests/Mediarq.Analyzers.Tests/PipelineBehaviorNextAnalyzerTests.cs
@@ -1,0 +1,139 @@
+using Mediarq.Analyzers;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+
+namespace Mediarq.Analyzers.Tests;
+
+public class PipelineBehaviorNextAnalyzerTests
+{
+    // Minimal stubs for the types the analyzer looks for by name/namespace/arity.
+    private const string Stubs = @"
+namespace Mediarq.Core.Common.Pipeline
+{
+    public interface IPipelineBehavior<TRequest, TResponse>
+    {
+        System.Threading.Tasks.Task<TResponse> Handle(object context, System.Func<System.Threading.Tasks.Task<TResponse>> handle, System.Threading.CancellationToken cancellationToken = default);
+    }
+}
+";
+
+    private static async Task VerifyAsync(string source, params DiagnosticResult[] expected)
+    {
+        var test = new CSharpAnalyzerTest<PipelineBehaviorNextAnalyzer, DefaultVerifier>
+        {
+            TestCode = source + Stubs,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+            CompilerDiagnostics = CompilerDiagnostics.None,
+        };
+        test.ExpectedDiagnostics.AddRange(expected);
+        await test.RunAsync();
+    }
+
+    private static DiagnosticResult Diagnostic(int markupKey)
+        => new DiagnosticResult(PipelineBehaviorNextAnalyzer.DiagnosticId, DiagnosticSeverity.Warning).WithLocation(markupKey);
+
+    [Fact]
+    public async Task Flags_A_Behavior_That_Never_References_The_Handle_Delegate()
+    {
+        const string source = @"
+using Mediarq.Core.Common.Pipeline;
+
+public class ForgetfulBehavior : IPipelineBehavior<object, string>
+{
+    public System.Threading.Tasks.Task<string> {|#0:Handle|}(object context, System.Func<System.Threading.Tasks.Task<string>> handle, System.Threading.CancellationToken cancellationToken = default)
+    {
+        return System.Threading.Tasks.Task.FromResult(""short-circuited"");
+    }
+}
+";
+        await VerifyAsync(source, Diagnostic(0).WithArguments("ForgetfulBehavior", "handle"));
+    }
+
+    [Fact]
+    public async Task Flags_An_Expression_Bodied_Behavior_That_Never_References_The_Handle_Delegate()
+    {
+        const string source = @"
+using Mediarq.Core.Common.Pipeline;
+
+public class ForgetfulBehavior : IPipelineBehavior<object, string>
+{
+    public System.Threading.Tasks.Task<string> {|#0:Handle|}(object context, System.Func<System.Threading.Tasks.Task<string>> handle, System.Threading.CancellationToken cancellationToken = default)
+        => System.Threading.Tasks.Task.FromResult(""short-circuited"");
+}
+";
+        await VerifyAsync(source, Diagnostic(0).WithArguments("ForgetfulBehavior", "handle"));
+    }
+
+    [Fact]
+    public Task Does_Not_Flag_A_Behavior_That_Calls_The_Handle_Delegate()
+        => VerifyAsync(@"
+using Mediarq.Core.Common.Pipeline;
+
+public class LoggingBehavior : IPipelineBehavior<object, string>
+{
+    public async System.Threading.Tasks.Task<string> Handle(object context, System.Func<System.Threading.Tasks.Task<string>> handle, System.Threading.CancellationToken cancellationToken = default)
+    {
+        return await handle();
+    }
+}
+");
+
+    [Fact]
+    public Task Does_Not_Flag_A_Behavior_That_Conditionally_Calls_The_Handle_Delegate()
+        => VerifyAsync(@"
+using Mediarq.Core.Common.Pipeline;
+
+public class CachingBehavior : IPipelineBehavior<object, string>
+{
+    private static bool _cached;
+
+    public async System.Threading.Tasks.Task<string> Handle(object context, System.Func<System.Threading.Tasks.Task<string>> handle, System.Threading.CancellationToken cancellationToken = default)
+    {
+        if (_cached)
+        {
+            return ""cached"";
+        }
+
+        return await handle();
+    }
+}
+");
+
+    [Fact]
+    public Task Does_Not_Flag_An_Explicit_Interface_Implementation_That_Calls_The_Handle_Delegate()
+        => VerifyAsync(@"
+using Mediarq.Core.Common.Pipeline;
+
+public class LoggingBehavior : IPipelineBehavior<object, string>
+{
+    async System.Threading.Tasks.Task<string> IPipelineBehavior<object, string>.Handle(object context, System.Func<System.Threading.Tasks.Task<string>> handle, System.Threading.CancellationToken cancellationToken)
+    {
+        return await handle();
+    }
+}
+");
+
+    [Fact]
+    public Task Does_Not_Flag_An_Abstract_Handle_Method()
+        => VerifyAsync(@"
+using Mediarq.Core.Common.Pipeline;
+
+public abstract class BehaviorBase : IPipelineBehavior<object, string>
+{
+    public abstract System.Threading.Tasks.Task<string> Handle(object context, System.Func<System.Threading.Tasks.Task<string>> handle, System.Threading.CancellationToken cancellationToken = default);
+}
+");
+
+    [Fact]
+    public Task Does_Not_Flag_An_Unrelated_Handle_Method()
+        => VerifyAsync(@"
+public class NotABehavior
+{
+    public System.Threading.Tasks.Task<string> Handle(object context, System.Func<System.Threading.Tasks.Task<string>> handle, System.Threading.CancellationToken cancellationToken = default)
+    {
+        return System.Threading.Tasks.Task.FromResult(""whatever"");
+    }
+}
+");
+}

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -45,6 +45,30 @@ This analyzer only compares **explicit** lifetimes (`[RegisterHandler(...)]` on 
 `services.AddScoped<T>()` calls outside the Mediarq registration model, so it stays silent rather than
 guess and risk a false positive.
 
+## Pipeline
+
+### Build warning `MQ201` — pipeline behavior never calls its `handle` delegate
+An `IPipelineBehavior<TRequest, TResponse>.Handle` implementation never references its `handle`
+parameter anywhere in its body. Every behavior after this one in the pipeline — and the actual request
+handler — will never run; the behavior always short-circuits with whatever it returns directly.
+
+```csharp
+public Task<TResponse> Handle(IMutableRequestContext<TRequest, TResponse> context, Func<Task<TResponse>> handle, CancellationToken cancellationToken = default)
+{
+    // Missing `return await handle();` — the request never reaches its handler.
+    return Task.FromResult(default(TResponse)!);
+}
+```
+
+Fix by calling `handle()` (typically `return await handle();`, or storing its result to act on
+afterwards). If the short-circuit is genuinely intentional (e.g. a behavior that always returns a
+canned response and never delegates further), the analyzer has no way to tell that apart from a bug —
+suppress the specific instance rather than the rule.
+
+This analyzer only requires `handle` to appear **somewhere** in the body, on any code path — a behavior
+that conditionally short-circuits (e.g. return a cached value on a hit, otherwise `await handle()`) is
+not flagged, since the identifier is still referenced on the miss path.
+
 ## Validation
 
 ### My validation never runs (no error, the handler just runs)

--- a/src/Mediarq.Analyzers/PipelineBehaviorNextAnalyzer.cs
+++ b/src/Mediarq.Analyzers/PipelineBehaviorNextAnalyzer.cs
@@ -1,0 +1,115 @@
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Mediarq.Analyzers;
+
+/// <summary>
+/// Reports an <c>IPipelineBehavior&lt;TRequest, TResponse&gt;.Handle</c> implementation that never
+/// references its <c>handle</c> delegate parameter anywhere in its body — the classic "forgot to call
+/// next" pipeline bug, which silently short-circuits the rest of the pipeline and the actual request
+/// handler (they simply never run).
+/// </summary>
+/// <remarks>
+/// The check only requires the parameter identifier to appear *somewhere* in the body, on any code path
+/// (e.g. a caching behavior that returns early on a cache hit but still calls it on a miss is not
+/// flagged) — it fires only when the delegate is never referenced at all, which is always a mistake, not
+/// a legitimate conditional short-circuit.
+/// </remarks>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class PipelineBehaviorNextAnalyzer : DiagnosticAnalyzer
+{
+    /// <summary>The diagnostic id reported when a pipeline behavior never calls its <c>handle</c> delegate.</summary>
+    public const string DiagnosticId = "MQ201";
+
+    private const string PipelineBehaviorInterfaceName = "IPipelineBehavior";
+    private const string PipelineBehaviorNamespace = "Mediarq.Core.Common.Pipeline";
+    private const string HandleMethodName = "Handle";
+
+    private static readonly DiagnosticDescriptor Rule = new(
+        id: DiagnosticId,
+        title: "Pipeline behavior never calls its 'handle' delegate",
+        messageFormat: "'{0}.Handle' never calls the '{1}' delegate — the rest of the pipeline (and the actual request handler) will never run",
+        category: "Mediarq.Pipeline",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "An IPipelineBehavior<TRequest, TResponse>.Handle implementation that never references its 'handle' delegate parameter short-circuits the pipeline on every call — almost always a bug rather than an intentional short-circuit.",
+        helpLinkUri: "https://github.com/rouffou/mediarq/blob/main/docs/guides/troubleshooting.md");
+
+    /// <inheritdoc />
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+    /// <inheritdoc />
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(AnalyzeMethod, SyntaxKind.MethodDeclaration);
+    }
+
+    private static void AnalyzeMethod(SyntaxNodeAnalysisContext context)
+    {
+        var methodSyntax = (MethodDeclarationSyntax)context.Node;
+        if (methodSyntax.Identifier.ValueText != HandleMethodName)
+        {
+            return;
+        }
+
+        SyntaxNode? body = methodSyntax.Body ?? (SyntaxNode?)methodSyntax.ExpressionBody;
+        if (body is null)
+        {
+            return; // abstract, partial without a body, or extern — nothing to check.
+        }
+
+        var semanticModel = context.SemanticModel;
+        if (semanticModel.GetDeclaredSymbol(methodSyntax, context.CancellationToken) is not IMethodSymbol method)
+        {
+            return;
+        }
+
+        var containingType = method.ContainingType;
+        var behaviorInterface = containingType?.AllInterfaces.FirstOrDefault(IsPipelineBehaviorInterface);
+        if (containingType is null || behaviorInterface is null)
+        {
+            return;
+        }
+
+        var interfaceHandleMethod = behaviorInterface.GetMembers(HandleMethodName).OfType<IMethodSymbol>().FirstOrDefault();
+        if (interfaceHandleMethod is null)
+        {
+            return;
+        }
+
+        // Confirm this specific method is the interface's implementation (not an unrelated overload).
+        if (!SymbolEqualityComparer.Default.Equals(containingType.FindImplementationForInterfaceMember(interfaceHandleMethod), method))
+        {
+            return;
+        }
+
+        // IPipelineBehavior<,>.Handle(context, handle, cancellationToken) — the delegate is parameter 1.
+        if (method.Parameters.Length < 2)
+        {
+            return;
+        }
+
+        var delegateParameter = method.Parameters[1];
+
+        var referencesDelegate = body.DescendantNodes()
+            .OfType<IdentifierNameSyntax>()
+            .Any(id => SymbolEqualityComparer.Default.Equals(
+                semanticModel.GetSymbolInfo(id, context.CancellationToken).Symbol, delegateParameter));
+
+        if (!referencesDelegate)
+        {
+            context.ReportDiagnostic(Diagnostic.Create(Rule, methodSyntax.Identifier.GetLocation(), containingType.Name, delegateParameter.Name));
+        }
+    }
+
+    private static bool IsPipelineBehaviorInterface(INamedTypeSymbol iface)
+        => iface.Arity == 2 &&
+           iface.Name == PipelineBehaviorInterfaceName &&
+           iface.ContainingNamespace?.ToDisplayString() == PipelineBehaviorNamespace;
+}

--- a/src/Mediarq.Analyzers/PublicAPI.Unshipped.txt
+++ b/src/Mediarq.Analyzers/PublicAPI.Unshipped.txt
@@ -1,1 +1,11 @@
 #nullable enable
+const Mediarq.Analyzers.CaptiveDependencyAnalyzer.DiagnosticId = "MQ200" -> string!
+const Mediarq.Analyzers.PipelineBehaviorNextAnalyzer.DiagnosticId = "MQ201" -> string!
+Mediarq.Analyzers.CaptiveDependencyAnalyzer
+Mediarq.Analyzers.CaptiveDependencyAnalyzer.CaptiveDependencyAnalyzer() -> void
+Mediarq.Analyzers.PipelineBehaviorNextAnalyzer
+Mediarq.Analyzers.PipelineBehaviorNextAnalyzer.PipelineBehaviorNextAnalyzer() -> void
+override Mediarq.Analyzers.CaptiveDependencyAnalyzer.Initialize(Microsoft.CodeAnalysis.Diagnostics.AnalysisContext! context) -> void
+override Mediarq.Analyzers.CaptiveDependencyAnalyzer.SupportedDiagnostics.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.DiagnosticDescriptor!>
+override Mediarq.Analyzers.PipelineBehaviorNextAnalyzer.Initialize(Microsoft.CodeAnalysis.Diagnostics.AnalysisContext! context) -> void
+override Mediarq.Analyzers.PipelineBehaviorNextAnalyzer.SupportedDiagnostics.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.DiagnosticDescriptor!>


### PR DESCRIPTION
## Summary
- New `Mediarq.Analyzers` rule `MQ201`: flags an `IPipelineBehavior<TRequest, TResponse>.Handle` implementation that never references its `handle` delegate parameter anywhere in its body — the interface's own XML doc already calls this out as a footgun ("omitting it short-circuits the request handling process"), but nothing previously caught it statically.
- Conservative by design: only fires when the identifier is referenced **nowhere** in the body. A behavior that conditionally short-circuits (return a cached value on a hit, `await handle()` otherwise — exactly what the built-in `CachingBehavior` does) is not flagged, since the identifier still appears on the miss path.
- Docs: new "Pipeline" section in `docs/guides/troubleshooting.md`.

Closes #37 (the issue's other two example rules — banned reflection path, missing handler — turned out to already be covered by the existing `MQ004` and `MQ002` source-generator diagnostics; I first drafted a "duplicate handler" rule for this issue but found it was redundant with the existing `MQ001`, so pivoted to this instead).

## Test plan
- [x] `dotnet build Mediarq.sln` — clean, no new warnings
- [x] `dotnet test Mediarq.sln` — full suite green, including 7 new tests covering: block body, expression body, conditional short-circuit (not flagged), explicit interface implementation, abstract method (not flagged), unrelated `Handle` method on a non-behavior type (not flagged)