### PR TITLE
fix(benchmarks,core): remove benchmark contamination + avoid async state machine on void dispatch

### DIFF
--- a/Tests/Mediarq.Tests/Core/Requests/Abstraction/RequestHandlerVoidAdapterTests.cs
+++ b/Tests/Mediarq.Tests/Core/Requests/Abstraction/RequestHandlerVoidAdapterTests.cs
@@ -1,0 +1,77 @@
+using FluentAssertions;
+using Mediarq.Core.Common.Requests.Abstraction;
+using Mediarq.Core.Common.Requests.Command;
+
+namespace Mediarq.Tests.Core.Requests.Abstraction;
+
+/// <summary>
+/// Exercises <see cref="IRequestHandler{TRequest}"/>'s default-interface adaptation to
+/// <see cref="IRequestHandler{TRequest, Unit}"/> directly (bypassing the mediator) to pin down its
+/// synchronous-completion fast path and its fallback for a genuinely asynchronous handler.
+/// </summary>
+public class RequestHandlerVoidAdapterTests
+{
+    private sealed record VoidCommand : ICommand;
+
+    private sealed class SyncCompletingHandler : ICommandHandler<VoidCommand>
+    {
+        public Task Handle(VoidCommand request, CancellationToken cancellationToken = default) => Task.CompletedTask;
+    }
+
+    private sealed class AsyncCompletingHandler : ICommandHandler<VoidCommand>
+    {
+        public async Task Handle(VoidCommand request, CancellationToken cancellationToken = default)
+        {
+            await Task.Yield();
+        }
+    }
+
+    private sealed class SyncThrowingHandler : ICommandHandler<VoidCommand>
+    {
+        public Task Handle(VoidCommand request, CancellationToken cancellationToken = default)
+            => throw new InvalidOperationException("sync boom");
+    }
+
+    private sealed class AsyncThrowingHandler : ICommandHandler<VoidCommand>
+    {
+        public async Task Handle(VoidCommand request, CancellationToken cancellationToken = default)
+        {
+            await Task.Yield();
+            throw new InvalidOperationException("async boom");
+        }
+    }
+
+    private static IRequestHandler<VoidCommand, Unit> Adapter(IRequestHandler<VoidCommand> handler) => handler;
+
+    [Fact]
+    public async Task Returns_Unit_Value_For_A_Synchronously_Completing_Handler()
+    {
+        var result = await Adapter(new SyncCompletingHandler()).Handle(new VoidCommand());
+
+        result.Should().Be(Unit.Value);
+    }
+
+    [Fact]
+    public async Task Returns_Unit_Value_For_A_Genuinely_Asynchronous_Handler()
+    {
+        var result = await Adapter(new AsyncCompletingHandler()).Handle(new VoidCommand());
+
+        result.Should().Be(Unit.Value);
+    }
+
+    [Fact]
+    public async Task Propagates_An_Exception_Thrown_Synchronously_By_The_Handler()
+    {
+        var act = () => Adapter(new SyncThrowingHandler()).Handle(new VoidCommand());
+
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("sync boom");
+    }
+
+    [Fact]
+    public async Task Propagates_An_Exception_Thrown_By_A_Genuinely_Asynchronous_Handler()
+    {
+        var act = () => Adapter(new AsyncThrowingHandler()).Handle(new VoidCommand());
+
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("async boom");
+    }
+}

--- a/benchmarks/Mediarq.Benchmarks/ExpandedBenchmarks.cs
+++ b/benchmarks/Mediarq.Benchmarks/ExpandedBenchmarks.cs
@@ -132,9 +132,17 @@ public class LifetimeBenchmarks
     [GlobalSetup]
     public void Setup()
     {
+        // AddMediarqCore() (not the scanning AddMediarq): the scanning path would auto-discover
+        // MediarqPassthroughBehavior (declared for DeepPipelineBenchmarks, above, in this same assembly)
+        // as a global open-generic behavior, so every dispatch below would pay for a 1-behavior pipeline
+        // instead of the bare handler call this benchmark means to measure. [RegisterHandler] on
+        // SingletonPingHandler is only honored by the scan/source-gen paths, so its lifetime is
+        // reproduced manually below via AddSingleton.
         var services = new ServiceCollection();
         services.AddLogging();
-        services.AddMediarq(isHttp: false, typeof(LifetimeBenchmarks).Assembly);
+        services.AddMediarqCore(isHttp: false);
+        services.AddScoped<IRequestHandler<ScopedPing, Result<string>>, ScopedPingHandler>();
+        services.AddSingleton<IRequestHandler<SingletonPing, Result<string>>, SingletonPingHandler>();
         _scope = services.BuildServiceProvider().CreateScope();
         _mediarq = _scope.ServiceProvider.GetRequiredService<MediarqMediator>();
     }
@@ -190,9 +198,43 @@ public class ManyHandlersBenchmarks
     [GlobalSetup]
     public void Setup()
     {
+        // AddMediarqCore() (not the scanning AddMediarq): the scanning path would auto-discover
+        // MediarqPassthroughBehavior (declared for DeepPipelineBenchmarks, above, in this same assembly)
+        // as a global open-generic behavior, so every dispatch below would pay for a 1-behavior pipeline
+        // that MediatR's own registration (no auto-discovered IPipelineBehavior) never pays for.
         var mediarqServices = new ServiceCollection();
         mediarqServices.AddLogging();
-        mediarqServices.AddMediarq(isHttp: false, typeof(ManyHandlersBenchmarks).Assembly);
+        mediarqServices.AddMediarqCore(isHttp: false);
+        mediarqServices.AddScoped<IRequestHandler<MediarqManyHandlersPing1, Result<string>>, MediarqManyHandlersPing1Handler>();
+        mediarqServices.AddScoped<IRequestHandler<MediarqManyHandlersPing2, Result<string>>, MediarqManyHandlersPing2Handler>();
+        mediarqServices.AddScoped<IRequestHandler<MediarqManyHandlersPing3, Result<string>>, MediarqManyHandlersPing3Handler>();
+        mediarqServices.AddScoped<IRequestHandler<MediarqManyHandlersPing4, Result<string>>, MediarqManyHandlersPing4Handler>();
+        mediarqServices.AddScoped<IRequestHandler<MediarqManyHandlersPing5, Result<string>>, MediarqManyHandlersPing5Handler>();
+        mediarqServices.AddScoped<IRequestHandler<MediarqManyHandlersPing6, Result<string>>, MediarqManyHandlersPing6Handler>();
+        mediarqServices.AddScoped<IRequestHandler<MediarqManyHandlersPing7, Result<string>>, MediarqManyHandlersPing7Handler>();
+        mediarqServices.AddScoped<IRequestHandler<MediarqManyHandlersPing8, Result<string>>, MediarqManyHandlersPing8Handler>();
+        mediarqServices.AddScoped<IRequestHandler<MediarqManyHandlersPing9, Result<string>>, MediarqManyHandlersPing9Handler>();
+        mediarqServices.AddScoped<IRequestHandler<MediarqManyHandlersPing10, Result<string>>, MediarqManyHandlersPing10Handler>();
+        mediarqServices.AddScoped<IRequestHandler<MediarqManyHandlersPing11, Result<string>>, MediarqManyHandlersPing11Handler>();
+        mediarqServices.AddScoped<IRequestHandler<MediarqManyHandlersPing12, Result<string>>, MediarqManyHandlersPing12Handler>();
+        mediarqServices.AddScoped<IRequestHandler<MediarqManyHandlersPing13, Result<string>>, MediarqManyHandlersPing13Handler>();
+        mediarqServices.AddScoped<IRequestHandler<MediarqManyHandlersPing14, Result<string>>, MediarqManyHandlersPing14Handler>();
+        mediarqServices.AddScoped<IRequestHandler<MediarqManyHandlersPing15, Result<string>>, MediarqManyHandlersPing15Handler>();
+        mediarqServices.AddScoped<IRequestHandler<MediarqManyHandlersPing16, Result<string>>, MediarqManyHandlersPing16Handler>();
+        mediarqServices.AddScoped<IRequestHandler<MediarqManyHandlersPing17, Result<string>>, MediarqManyHandlersPing17Handler>();
+        mediarqServices.AddScoped<IRequestHandler<MediarqManyHandlersPing18, Result<string>>, MediarqManyHandlersPing18Handler>();
+        mediarqServices.AddScoped<IRequestHandler<MediarqManyHandlersPing19, Result<string>>, MediarqManyHandlersPing19Handler>();
+        mediarqServices.AddScoped<IRequestHandler<MediarqManyHandlersPing20, Result<string>>, MediarqManyHandlersPing20Handler>();
+        mediarqServices.AddScoped<IRequestHandler<MediarqManyHandlersPing21, Result<string>>, MediarqManyHandlersPing21Handler>();
+        mediarqServices.AddScoped<IRequestHandler<MediarqManyHandlersPing22, Result<string>>, MediarqManyHandlersPing22Handler>();
+        mediarqServices.AddScoped<IRequestHandler<MediarqManyHandlersPing23, Result<string>>, MediarqManyHandlersPing23Handler>();
+        mediarqServices.AddScoped<IRequestHandler<MediarqManyHandlersPing24, Result<string>>, MediarqManyHandlersPing24Handler>();
+        mediarqServices.AddScoped<IRequestHandler<MediarqManyHandlersPing25, Result<string>>, MediarqManyHandlersPing25Handler>();
+        mediarqServices.AddScoped<IRequestHandler<MediarqManyHandlersPing26, Result<string>>, MediarqManyHandlersPing26Handler>();
+        mediarqServices.AddScoped<IRequestHandler<MediarqManyHandlersPing27, Result<string>>, MediarqManyHandlersPing27Handler>();
+        mediarqServices.AddScoped<IRequestHandler<MediarqManyHandlersPing28, Result<string>>, MediarqManyHandlersPing28Handler>();
+        mediarqServices.AddScoped<IRequestHandler<MediarqManyHandlersPing29, Result<string>>, MediarqManyHandlersPing29Handler>();
+        mediarqServices.AddScoped<IRequestHandler<MediarqManyHandlersPing30, Result<string>>, MediarqManyHandlersPing30Handler>();
         _mediarqScope = mediarqServices.BuildServiceProvider().CreateScope();
         _mediarq = _mediarqScope.ServiceProvider.GetRequiredService<MediarqMediator>();
 
@@ -602,9 +644,17 @@ public class CrossLibraryBenchmarks
     [GlobalSetup]
     public async Task Setup()
     {
+        // AddMediarqCore() (not the scanning AddMediarq): the scanning path would auto-discover
+        // MediarqPassthroughBehavior (declared for DeepPipelineBenchmarks, above, in this same assembly)
+        // as a global open-generic behavior, so Mediarq_Send_Void would pay for a 1-behavior pipeline
+        // the other three libraries below never pay for. Both interface forms are registered because the
+        // dispatch pipeline resolves the 2-arg IRequestHandler<,Unit> for a void command, matching what
+        // Scrutor's AsImplementedInterfaces (used by AddMediarq) would have registered.
         var mediarqServices = new ServiceCollection();
         mediarqServices.AddLogging();
-        mediarqServices.AddMediarq(isHttp: false, typeof(CrossLibraryBenchmarks).Assembly);
+        mediarqServices.AddMediarqCore(isHttp: false);
+        mediarqServices.AddScoped<IRequestHandler<MediarqVoidPing>, MediarqVoidPingHandler>();
+        mediarqServices.AddScoped<IRequestHandler<MediarqVoidPing, Unit>, MediarqVoidPingHandler>();
         _mediarqScope = mediarqServices.BuildServiceProvider().CreateScope();
         _mediarq = _mediarqScope.ServiceProvider.GetRequiredService<MediarqMediator>();
 

--- a/src/Mediarq.Core/Common/Requests/Abstraction/IRequestHandler.cs
+++ b/src/Mediarq.Core/Common/Requests/Abstraction/IRequestHandler.cs
@@ -73,9 +73,20 @@ public interface IRequestHandler<in TRequest> : IRequestHandler<TRequest, Unit>
     /// <param name="request">The request message containing all data required for processing.</param>
     /// <param name="cancellationToken">A token that can be used to cancel the operation.</param>
     /// <returns>A task that completes with <see cref="Unit.Value"/>.</returns>
-    async Task<Unit> IRequestHandler<TRequest, Unit>.Handle(TRequest request, CancellationToken cancellationToken)
+    /// <remarks>
+    /// Written without <c>async</c>/<c>await</c> so a handler that completes synchronously (the common
+    /// case for a trivial no-op or a handler returning <see cref="Task.CompletedTask"/>) does not pay for
+    /// an async state machine on every dispatch — only a genuinely asynchronous handler falls back to it.
+    /// </remarks>
+    Task<Unit> IRequestHandler<TRequest, Unit>.Handle(TRequest request, CancellationToken cancellationToken)
     {
-        await ((IRequestHandler<TRequest>)this).Handle(request, cancellationToken);
-        return Unit.Value;
+        var task = ((IRequestHandler<TRequest>)this).Handle(request, cancellationToken);
+        return task.IsCompletedSuccessfully ? Task.FromResult(Unit.Value) : Awaited(task);
+
+        static async Task<Unit> Awaited(Task task)
+        {
+            await task.ConfigureAwait(false);
+            return Unit.Value;
+        }
     }
 }


### PR DESCRIPTION
## Summary

Investigates and resolves most of #163 (Mediarq dispatch overhead vs MediatR).

**Root cause (benchmark methodology bug, not a real library problem):** `ManyHandlersBenchmarks`, `CrossLibraryBenchmarks` and `LifetimeBenchmarks` set up Mediarq via the scanning `AddMediarq(...)`, which auto-discovers every `IPipelineBehavior<,>` in the target assembly. That assembly also declares `MediarqPassthroughBehavior<,>` for `DeepPipelineBenchmarks` — so it got silently picked up as a *global* open-generic behavior, meaning every "base dispatch" benchmark actually measured a 1-behavior pipeline. MediatR's own `RegisterServicesFromAssembly` never auto-discovers `IPipelineBehavior`s, so the comparison was apples-to-oranges. `DeepPipelineBenchmarks` already avoided this (comment in the code even calls it out) by wiring services manually instead of scanning — the other three benchmarks just weren't protected the same way.

**Fix:** switched those three `[GlobalSetup]` methods to `AddMediarqCore()` (registers Mediarq's own built-in behaviors, but they're all `IConditionalPipelineBehavior` and inactive for these plain ping commands) + explicit handler registrations, instead of the scanning `AddMediarq(...)`.

**Secondary fix (real, small, product-level):** `IRequestHandler<TRequest>`'s default-interface adaptation to `IRequestHandler<TRequest, Unit>` was `async`/`await`, paying for a state-machine allocation+continuation on every void-command dispatch even when the inner handler completes synchronously (the common case — e.g. `Task.CompletedTask`). Rewritten to check `Task.IsCompletedSuccessfully` and only fall back to an async local function when the handler is genuinely asynchronous. No public API change (default-interface-method body only).

## Results (ShortRun, .NET 10.0.10, Windows 11)

| Benchmark | Before | After |
|---|---|---|
| `ManyHandlersBenchmarks` (Mediarq vs MediatR) | 115.65 ns / 616 B, ratio **3.20x** | 77.60 ns / 240 B, ratio **2.23x** |
| `CrossLibraryBenchmarks.Mediarq_Send_Void` | 115.75 ns / 432 B, ratio **2.89x** | 68.48 ns / 56 B, ratio **1.58x** |
| `LifetimeBenchmarks` (scoped handler) | 134.0 ns / 616 B | 77.04 ns / 240 B |

The allocation numbers now land almost exactly where a plaintext root-cause analysis predicted (~200–250 B), confirming the diagnosis: the overhead did not grow with registered handler count, it was a constant benchmark-setup artifact plus one avoidable allocation.

Residual ~1.6–2.2x gap is now attributable to known, already-documented, minor factors (the `Result<T>` wrapper allocation vs a raw `string`, `RequestContext` creation + `IUserContext` resolution when at least one conditional behavior check runs) — not tracked as a further action item here.

## Test plan
- [x] `dotnet build Mediarq.sln` — clean, no new warnings, no PublicAPI diff
- [x] `dotnet test Mediarq.sln` — full suite green (180/180 in `Mediarq.Tests`, incl. 4 new tests pinning the sync-fast-path / async-fallback / sync-throw / async-throw behavior of the rewritten adapter)
- [x] Re-ran `ManyHandlersBenchmarks`, `CrossLibraryBenchmarks`, `LifetimeBenchmarks` (`--job short`) locally — numbers above