### PR TITLE
feat(ci): track allocation regression alongside mean time in the benchmark guardrail

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -15,7 +15,11 @@ name: Benchmarks
 # Send and Publish are tracked in separate jobs (not two steps in one job): the action commits to a
 # local gh-pages checkout as part of every run regardless of save-data-file/auto-push, so a second
 # invocation in the same checkout always fails to re-fetch gh-pages against its own already-diverged
-# local ref. Separate jobs get separate, independent checkouts.
+# local ref. Separate jobs get separate, independent checkouts. The same constraint is why allocation
+# tracking (`benchmark-alloc` below) is its own job per matrix entry rather than a second
+# github-action-benchmark step tacked onto `benchmark`: it downloads the JSON artifact `benchmark`
+# already produced instead of re-running BenchmarkDotNet, so the extra job costs a converter script and
+# an upload/download round-trip, not a second benchmark run.
 
 on:
   push:
@@ -24,6 +28,7 @@ on:
       - 'src/Mediarq.Core/**'
       - 'src/Mediarq/**'
       - 'benchmarks/**'
+      - 'scripts/benchmarkdotnet-alloc-report.mjs'
       - '.github/workflows/benchmarks.yml'
   pull_request:
     branches: [ dev, main ]
@@ -31,6 +36,7 @@ on:
       - 'src/Mediarq.Core/**'
       - 'src/Mediarq/**'
       - 'benchmarks/**'
+      - 'scripts/benchmarkdotnet-alloc-report.mjs'
       - '.github/workflows/benchmarks.yml'
   workflow_dispatch:
 
@@ -79,6 +85,46 @@ jobs:
           name: 'Mediarq.Benchmarks - ${{ matrix.display-name }}'
           tool: 'benchmarkdotnet'
           output-file-path: BenchmarkDotNet.Artifacts/results/${{ matrix.report-file }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: ${{ github.event_name == 'push' }}
+          fail-on-alert: false
+          comment-on-alert: true
+          alert-threshold: '150%'
+
+  # github-action-benchmark's built-in `benchmarkdotnet` tool (above) only tracks the Mean time
+  # statistic; it does not read BenchmarkDotNet's MemoryDiagnoser output. This job converts the same
+  # JSON report into github-action-benchmark's generic `customSmallerIsBetter` format (see
+  # scripts/benchmarkdotnet-alloc-report.mjs) to track allocated bytes per operation as its own,
+  # independently-alerted metric — closing the "alloc" half of the guardrail alongside "mean" above.
+  benchmark-alloc:
+    needs: benchmark
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - display-name: Send
+            report-file: SendBenchmarks-report-full-compressed.json
+          - display-name: Publish
+            report-file: PublishBenchmarks-report-full-compressed.json
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download ${{ matrix.display-name }} benchmark results
+        uses: actions/download-artifact@v4
+        with:
+          name: benchmark-results-${{ matrix.display-name }}
+          path: BenchmarkDotNet.Artifacts/results
+
+      - name: Convert to an allocation report
+        run: node scripts/benchmarkdotnet-alloc-report.mjs BenchmarkDotNet.Artifacts/results/${{ matrix.report-file }} alloc-report.json
+
+      - name: Track ${{ matrix.display-name }} allocation history
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: 'Mediarq.Benchmarks - ${{ matrix.display-name }} (Allocated)'
+          tool: 'customSmallerIsBetter'
+          output-file-path: alloc-report.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
           auto-push: ${{ github.event_name == 'push' }}
           fail-on-alert: false

--- a/scripts/benchmarkdotnet-alloc-report.mjs
+++ b/scripts/benchmarkdotnet-alloc-report.mjs
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+// Converts a BenchmarkDotNet "full" JSON export (--exporters json) into the JSON array format
+// github-action-benchmark's `customSmallerIsBetter` tool expects, tracking allocated bytes per
+// operation. github-action-benchmark's built-in `benchmarkdotnet` tool only tracks the Mean time
+// statistic, not BenchmarkDotNet's MemoryDiagnoser output, so this fills that gap as a second,
+// independently-tracked metric.
+
+import { readFileSync, writeFileSync } from "node:fs";
+
+const [, , inputPath, outputPath] = process.argv;
+
+if (!inputPath || !outputPath) {
+  console.error("Usage: node benchmarkdotnet-alloc-report.mjs <input-full-report.json> <output.json>");
+  process.exit(1);
+}
+
+const report = JSON.parse(readFileSync(inputPath, "utf8"));
+
+const entries = (report.Benchmarks ?? [])
+  .filter((b) => typeof b.Memory?.BytesAllocatedPerOperation === "number")
+  .map((b) => ({
+    name: `${b.FullName} - Allocated`,
+    unit: "B",
+    value: b.Memory.BytesAllocatedPerOperation,
+  }));
+
+writeFileSync(outputPath, JSON.stringify(entries, null, 2));
+
+console.log(`Wrote ${entries.length} allocation entrie(s) from ${inputPath} to ${outputPath}`);


### PR DESCRIPTION
## Summary
- github-action-benchmark's built-in `benchmarkdotnet` tool only tracks BenchmarkDotNet's Mean time statistic; it does not read the `MemoryDiagnoser` output, so an allocation regression could pass the existing guardrail unnoticed.
- New `scripts/benchmarkdotnet-alloc-report.mjs`: converts a BenchmarkDotNet full JSON export (`Memory.BytesAllocatedPerOperation`) into github-action-benchmark's generic `customSmallerIsBetter` format.
- New `benchmark-alloc` job in `.github/workflows/benchmarks.yml` (one per Send/Publish matrix entry, `needs: benchmark`): downloads the JSON artifact the existing `benchmark` job already produces (no re-running BenchmarkDotNet), converts it, and tracks allocated bytes as its own alerted history series (150% threshold, same as the existing mean-time tracking, report-only — never fails the build).
- Kept as a separate job rather than a second step in `benchmark`, for the same reason Send/Publish are already split into separate jobs: `github-action-benchmark` commits to a local `gh-pages` checkout on every invocation, and a second invocation in the same checkout fails to re-fetch against its own already-diverged local ref.

Closes #179

## Test plan
- [x] Ran the actual benchmark locally (`dotnet run -c Release --project benchmarks/Mediarq.Benchmarks -- --filter '*SendBenchmarks.Mediarq_Send_Plain*' --job short --exporters json`) and verified the exported JSON's `Memory.BytesAllocatedPerOperation`/`FullName` fields against the converter's assumptions
- [x] Ran `node scripts/benchmarkdotnet-alloc-report.mjs` against that real report and confirmed the `customSmallerIsBetter` output shape
- [ ] CI: the new `benchmark-alloc` job itself (download-artifact → convert → github-action-benchmark) can only be exercised by actually running in Actions — watching this PR's checks for that