### PR TITLE
perf(core): cache empty-pipeline fact per request type to skip ResolveAll on repeat dispatch

### DIFF
--- a/Tests/Mediarq.Tests/Core/Common/Pipeline/PipelineExecutorTests.cs
+++ b/Tests/Mediarq.Tests/Core/Common/Pipeline/PipelineExecutorTests.cs
@@ -285,6 +285,104 @@ public class PipelineExecutorTests
         factory.Verify(f => f.Create<TestCommandWithValue, Result<string>>(request, It.IsAny<CancellationToken>()), Times.Once);
     }
 
+    [Fact]
+    public async Task ExecuteAsync_Should_ResolveAll_Only_Once_When_No_Behaviors_Are_Registered()
+    {
+        // Arrange — a real cache so the executor can memoize "zero behaviors registered".
+        var resolver = new Mock<IHandlerResolver>();
+        resolver
+            .Setup(r => r.Resolve<PipelineBehaviorRegistrationCache>())
+            .Returns(new PipelineBehaviorRegistrationCache());
+        resolver
+            .Setup(r => r.ResolveAll<IPipelineBehavior<TestCommandWithValue, Result<string>>>())
+            .Returns(Array.Empty<IPipelineBehavior<TestCommandWithValue, Result<string>>>());
+
+        var executor = new PipelineExecutor(resolver.Object);
+        var context = new RequestContext<TestCommandWithValue, Result<string>>(new TestCommandWithValue(""), "user");
+
+        // Act — dispatch twice.
+        await executor.ExecuteAsync(context, _ => Task.FromResult(Result.Success("OK")));
+        await executor.ExecuteAsync(context, _ => Task.FromResult(Result.Success("OK")));
+
+        // Assert — the second dispatch skipped ResolveAll entirely, using the memoized "empty" fact.
+        resolver.Verify(
+            r => r.ResolveAll<IPipelineBehavior<TestCommandWithValue, Result<string>>>(),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_LazyContext_Should_ResolveAll_Only_Once_When_No_Behaviors_Are_Registered()
+    {
+        var resolver = new Mock<IHandlerResolver>();
+        resolver
+            .Setup(r => r.Resolve<PipelineBehaviorRegistrationCache>())
+            .Returns(new PipelineBehaviorRegistrationCache());
+        resolver
+            .Setup(r => r.ResolveAll<IPipelineBehavior<TestCommandWithValue, Result<string>>>())
+            .Returns(Array.Empty<IPipelineBehavior<TestCommandWithValue, Result<string>>>());
+
+        var handler = new Mock<Mediarq.Core.Common.Requests.Abstraction.IRequestHandler<TestCommandWithValue, Result<string>>>();
+        handler.Setup(h => h.Handle(It.IsAny<TestCommandWithValue>(), It.IsAny<CancellationToken>()))
+               .ReturnsAsync(Result.Success("OK"));
+        var factory = new Mock<IRequestContextFactory>();
+
+        var executor = new PipelineExecutor(resolver.Object);
+
+        await executor.ExecuteAsync(new TestCommandWithValue("x"), handler.Object, factory.Object, CancellationToken.None);
+        await executor.ExecuteAsync(new TestCommandWithValue("x"), handler.Object, factory.Object, CancellationToken.None);
+
+        resolver.Verify(
+            r => r.ResolveAll<IPipelineBehavior<TestCommandWithValue, Result<string>>>(),
+            Times.Once);
+        handler.Verify(h => h.Handle(It.IsAny<TestCommandWithValue>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Should_Never_Cache_When_Behaviors_Are_Registered_Even_If_All_Inactive()
+    {
+        // Arrange — structurally non-empty (one registered behavior), but inactive every time: this must
+        // be re-evaluated on every dispatch, never memoized as "empty".
+        var log = new List<string>();
+        var resolver = new Mock<IHandlerResolver>();
+        resolver
+            .Setup(r => r.Resolve<PipelineBehaviorRegistrationCache>())
+            .Returns(new PipelineBehaviorRegistrationCache());
+        resolver
+            .Setup(r => r.ResolveAll<IPipelineBehavior<TestCommandWithValue, Result<string>>>())
+            .Returns(new IPipelineBehavior<TestCommandWithValue, Result<string>>[] { new ConditionalBehavior(isActive: false, "Inactive", log) });
+
+        var executor = new PipelineExecutor(resolver.Object);
+        var context = new RequestContext<TestCommandWithValue, Result<string>>(new TestCommandWithValue(""), "user");
+
+        await executor.ExecuteAsync(context, _ => Task.FromResult(Result.Success("OK")));
+        await executor.ExecuteAsync(context, _ => Task.FromResult(Result.Success("OK")));
+
+        resolver.Verify(
+            r => r.ResolveAll<IPipelineBehavior<TestCommandWithValue, Result<string>>>(),
+            Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Should_ResolveAll_Every_Time_When_No_Cache_Is_Registered()
+    {
+        // Arrange — no PipelineBehaviorRegistrationCache registered in the container (e.g. a hand-built
+        // resolver in a test): falls back to resolving on every dispatch, exactly like before this change.
+        var resolver = new Mock<IHandlerResolver>();
+        resolver
+            .Setup(r => r.ResolveAll<IPipelineBehavior<TestCommandWithValue, Result<string>>>())
+            .Returns(Array.Empty<IPipelineBehavior<TestCommandWithValue, Result<string>>>());
+
+        var executor = new PipelineExecutor(resolver.Object);
+        var context = new RequestContext<TestCommandWithValue, Result<string>>(new TestCommandWithValue(""), "user");
+
+        await executor.ExecuteAsync(context, _ => Task.FromResult(Result.Success("OK")));
+        await executor.ExecuteAsync(context, _ => Task.FromResult(Result.Success("OK")));
+
+        resolver.Verify(
+            r => r.ResolveAll<IPipelineBehavior<TestCommandWithValue, Result<string>>>(),
+            Times.Exactly(2));
+    }
+
     private sealed class OrderedBehavior(int order, string name, List<string> log)
         : IPipelineBehavior<TestCommandWithValue, Result<string>>, IOrderBehavior
     {

--- a/Tests/Mediarq.Tests/Extensions/ServiceCollectionExtensionsTests.cs
+++ b/Tests/Mediarq.Tests/Extensions/ServiceCollectionExtensionsTests.cs
@@ -81,4 +81,22 @@ public class ServiceCollectionExtensionsTests
         ((Action)(() => services.AddMediarqTimeout())).Should().Throw<ArgumentNullException>();
         ((Action)(() => services.AddMediarq())).Should().Throw<ArgumentNullException>();
     }
+
+    [Fact]
+    public void AddMediarqCore_Registers_PipelineBehaviorRegistrationCache_As_A_Singleton_Shared_Across_Scopes()
+    {
+        var services = new ServiceCollection();
+
+        services.AddMediarqCore();
+        var provider = services.BuildServiceProvider();
+
+        using var scope1 = provider.CreateScope();
+        using var scope2 = provider.CreateScope();
+        var cache1 = scope1.ServiceProvider.GetRequiredService<PipelineBehaviorRegistrationCache>();
+        var cache2 = scope2.ServiceProvider.GetRequiredService<PipelineBehaviorRegistrationCache>();
+
+        // Same instance across independent scopes: the "empty pipeline" memo must outlive a single
+        // request scope, or repeat dispatches across scopes would never benefit from it.
+        cache1.Should().BeSameAs(cache2);
+    }
 }

--- a/src/Mediarq.Core/Common/Pipeline/PipelineBehaviorRegistrationCache.cs
+++ b/src/Mediarq.Core/Common/Pipeline/PipelineBehaviorRegistrationCache.cs
@@ -1,0 +1,28 @@
+using System.Collections.Concurrent;
+using Mediarq.Core.Common.Requests.Abstraction;
+
+namespace Mediarq.Core.Common.Pipeline;
+
+/// <summary>
+/// Per-container memo of which closed <see cref="IPipelineBehavior{TRequest, TResponse}"/> types have
+/// zero registrations, so a repeat dispatch can skip resolving an empty <c>IEnumerable&lt;&gt;</c> for
+/// that type. Register as a singleton — never as a static/process-wide cache — since a process can host
+/// multiple DI containers (e.g. across tests) with different registrations for the same closed types.
+/// </summary>
+/// <remarks>
+/// Only ever records "definitely zero behaviors are registered": a structural, DI-registration-time fact
+/// that cannot change once the container is built, so it is safe to cache forever after the first
+/// observation. It deliberately never records "no <em>active</em> behavior this time" —
+/// <see cref="IConditionalPipelineBehavior.IsActive"/> is per-request runtime state and must be
+/// re-evaluated on every dispatch.
+/// </remarks>
+public sealed class PipelineBehaviorRegistrationCache
+{
+    private readonly ConcurrentDictionary<Type, bool> _knownEmpty = new();
+
+    internal bool IsKnownEmpty<TRequest, TResponse>() where TRequest : ICommandOrQuery<TResponse>
+        => _knownEmpty.ContainsKey(typeof(IPipelineBehavior<TRequest, TResponse>));
+
+    internal void MarkKnownEmpty<TRequest, TResponse>() where TRequest : ICommandOrQuery<TResponse>
+        => _knownEmpty.TryAdd(typeof(IPipelineBehavior<TRequest, TResponse>), true);
+}

--- a/src/Mediarq.Core/Common/Pipeline/PipelineExecutor.cs
+++ b/src/Mediarq.Core/Common/Pipeline/PipelineExecutor.cs
@@ -21,6 +21,12 @@ public class PipelineExecutor(IHandlerResolver handlerResolver) : IPipelineExecu
 {
     private readonly IHandlerResolver _handlerResolver = handlerResolver;
 
+    // Resolved once per PipelineExecutor instance (i.e. once per scope) through the existing resolver
+    // rather than added as a constructor parameter, so this stays a non-breaking change to an
+    // already-shipped constructor signature. Null when the container has no such registration (e.g. a
+    // hand-built PipelineExecutor in a test) — every use below is null-conditional.
+    private readonly PipelineBehaviorRegistrationCache? _behaviorRegistrationCache = handlerResolver.Resolve<PipelineBehaviorRegistrationCache>();
+
     /// <summary>
     /// Executes the request pipeline for a given request and response type.
     /// </summary>
@@ -79,7 +85,22 @@ public class PipelineExecutor(IHandlerResolver handlerResolver) : IPipelineExecu
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(handlerDelegate);
 
+        // Memoized fast path: this closed request/response type is known, from a prior dispatch, to have
+        // zero registered behaviors — skip the IEnumerable<> resolution entirely. See
+        // PipelineBehaviorRegistrationCache for why only "zero registered" is ever cached here.
+        if (_behaviorRegistrationCache?.IsKnownEmpty<TRequest, TResponse>() == true)
+        {
+            return handlerDelegate(cancellationToken);
+        }
+
         var behaviors = _handlerResolver.ResolveAll<IPipelineBehavior<TRequest, TResponse>>();
+
+        if (behaviors.Count == 0)
+        {
+            _behaviorRegistrationCache?.MarkKnownEmpty<TRequest, TResponse>();
+            return handlerDelegate(cancellationToken);
+        }
+
         var active = PipelineDispatch.SelectActive<TRequest, TResponse>(behaviors, out var activeCount);
 
         // No active behavior: invoke the handler directly, with none of the chain/closure overhead.
@@ -103,7 +124,19 @@ public class PipelineExecutor(IHandlerResolver handlerResolver) : IPipelineExecu
         ArgumentNullException.ThrowIfNull(handler);
         ArgumentNullException.ThrowIfNull(contextFactory);
 
+        if (_behaviorRegistrationCache?.IsKnownEmpty<TRequest, TResponse>() == true)
+        {
+            return handler.Handle(request, cancellationToken);
+        }
+
         var behaviors = _handlerResolver.ResolveAll<IPipelineBehavior<TRequest, TResponse>>();
+
+        if (behaviors.Count == 0)
+        {
+            _behaviorRegistrationCache?.MarkKnownEmpty<TRequest, TResponse>();
+            return handler.Handle(request, cancellationToken);
+        }
+
         var active = PipelineDispatch.SelectActive<TRequest, TResponse>(behaviors, out var activeCount);
 
         // No active behavior: skip the request context allocation and the delegate entirely, invoking

--- a/src/Mediarq.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Mediarq.Core/Extensions/ServiceCollectionExtensions.cs
@@ -244,6 +244,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IPublisher>(sp => sp.GetRequiredService<IMediator>());
 
         services.TryAddSingleton<IClock, SystemClock>();
+        services.TryAddSingleton<PipelineBehaviorRegistrationCache>();
         services.TryAddScoped<IRequestContextFactory, RequestContextFactory>();
         services.TryAddScoped<IPipelineExecutor, PipelineExecutor>();
         services.TryAddScoped<IStreamPipelineExecutor, StreamPipelineExecutor>();

--- a/src/Mediarq.Core/PublicAPI.Unshipped.txt
+++ b/src/Mediarq.Core/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Mediarq.Core.Common.Pipeline.PipelineBehaviorRegistrationCache
+Mediarq.Core.Common.Pipeline.PipelineBehaviorRegistrationCache.PipelineBehaviorRegistrationCache() -> void


### PR DESCRIPTION
## Summary
- `ResolveAll<IPipelineBehavior<TReq,TRes>>()` was paid on every `Send`, even for a closed type with zero registered behaviors — pure DI resolution cost with no value.
- New `PipelineBehaviorRegistrationCache`: a per-container singleton that memoizes, per closed request/response type, that zero behaviors are registered. `PipelineExecutor` checks it first and skips the `IEnumerable<>` resolution on a cache hit.
- Only the "zero registered" fact is ever cached — a structural, DI-registration-time invariant that cannot change after the container is built. Whether a *registered* behavior is currently *active* (`IConditionalPipelineBehavior.IsActive`) stays a per-request runtime check, re-evaluated on every dispatch as before.
- Registered as a singleton (`AddCoreServices`), not a static/process-wide cache: a process can build multiple DI containers with different registrations for the same closed types (tests routinely do this), so the cache must live and die with its own container.
- `PipelineExecutor` resolves the cache once, in its constructor, through the existing `IHandlerResolver.Resolve<T>()` — not as a new constructor parameter — so its already-shipped (v1.4.0) public constructor signature is unchanged. `PublicAPI.Unshipped.txt` only gains the new (empty-surface, mostly-internal) cache type.

Closes #177

## Test plan
- [x] `dotnet build Mediarq.sln -c Release` — clean, zero new warnings
- [x] `dotnet test Mediarq.sln -c Release` — full suite green (185/185 in `Mediarq.Tests`, up from 180: 5 new tests covering both `ExecuteAsync` overloads — cache hit skips `ResolveAll`, structurally-non-empty-but-all-inactive is never cached, and the no-cache-registered fallback matches pre-change behavior — plus a DI test proving the cache is the same singleton instance across two scopes)
- [x] Ran `SendBenchmarks` locally before/after: numbers are within ShortRun noise (large error margins at this scale) — expected, since this targets DI *resolution* CPU cost (dictionary/callsite lookup), not allocation; .NET's container already returns a cached empty array for an unregistered `IEnumerable<T>`, so no allocation delta was expected either