### PR TITLE
fix(ci): never let a missing/unreachable gh-pages branch fail the benchmark jobs

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -79,8 +79,15 @@ jobs:
 
       # auto-push only on a push to dev/main: a PR run compares against history without writing to it,
       # so a PR's short-job, potentially-noisy numbers never become part of the trend.
+      #
+      # continue-on-error: this step hard-fails (not just "alerts") if the gh-pages data branch is ever
+      # missing or unreachable -- e.g. it was manually deleted -- which would otherwise turn a report-only
+      # signal into a build-blocking failure, contradicting this workflow's own design (see header
+      # comment). A hard failure here should be investigated (the trend history stops advancing), but it
+      # must never fail the job.
       - name: Track ${{ matrix.display-name }} dispatch history
         uses: benchmark-action/github-action-benchmark@v1
+        continue-on-error: true
         with:
           name: 'Mediarq.Benchmarks - ${{ matrix.display-name }}'
           tool: 'benchmarkdotnet'
@@ -119,8 +126,11 @@ jobs:
       - name: Convert to an allocation report
         run: node scripts/benchmarkdotnet-alloc-report.mjs BenchmarkDotNet.Artifacts/results/${{ matrix.report-file }} alloc-report.json
 
+      # See the continue-on-error note on the "Track ... dispatch history" step in the benchmark job above
+      # -- same reasoning applies here.
       - name: Track ${{ matrix.display-name }} allocation history
         uses: benchmark-action/github-action-benchmark@v1
+        continue-on-error: true
         with:
           name: 'Mediarq.Benchmarks - ${{ matrix.display-name }} (Allocated)'
           tool: 'customSmallerIsBetter'


### PR DESCRIPTION
## Summary
- PR #194's `benchmark` job (Send + Publish) failed with `fatal: couldn't find remote ref gh-pages` — the `gh-pages` branch backing `github-action-benchmark`'s history had disappeared from origin, despite existing and being fetched successfully during PR #193's own CI run minutes earlier. Root cause unclear (not caused by either PR's diff); restored the branch by pushing back the last-known `refs/remotes/origin/gh-pages` local ref, which still had the full accumulated commit history.
- Regardless of root cause, this exposed a real gap: `benchmarks.yml`'s own header comment says "Never fails the build ... this is a signal for review, not a merge blocker", but a hard git failure (missing/unreachable branch, transient network error, etc.) in the `github-action-benchmark` step was **not** covered by that guarantee — only the alert-threshold path (`fail-on-alert: false`) was.
- Add `continue-on-error: true` to both "Track ... history" steps (mean-time in `benchmark`, allocation in `benchmark-alloc`) so this class of failure degrades to a stopped trend (visible as a skipped/warning step) instead of a red, build-blocking check — matching the workflow's documented intent.

## Test plan
- [x] `gh-pages` branch restored and verified reachable (reran PR #194's previously-failing benchmark jobs against it)
- [ ] This PR's own CI run exercises the new `continue-on-error` on a working gh-pages branch (expected: normal pass, no behavior change in the happy path)