### PR TITLE
feat(authorization): add Mediarq.Authorization package for policy-based authorization

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,7 @@ jobs:
           dotnet pack src/Mediarq.Hangfire/Mediarq.Hangfire.csproj --no-build -c Release -p:Version=${{ steps.version.outputs.version }} -o ./artifacts
           dotnet pack src/Mediarq.Quartz/Mediarq.Quartz.csproj --no-build -c Release -p:Version=${{ steps.version.outputs.version }} -o ./artifacts
           dotnet pack src/Mediarq.HealthChecks/Mediarq.HealthChecks.csproj --no-build -c Release -p:Version=${{ steps.version.outputs.version }} -o ./artifacts
+          dotnet pack src/Mediarq.Authorization/Mediarq.Authorization.csproj --no-build -c Release -p:Version=${{ steps.version.outputs.version }} -o ./artifacts
 
       - name: NuGet login (trusted publishing)
         id: login

--- a/Mediarq.sln
+++ b/Mediarq.sln
@@ -103,6 +103,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mediarq.HealthChecks", "src
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mediarq.HealthChecks.Tests", "Tests\Mediarq.HealthChecks.Tests\Mediarq.HealthChecks.Tests.csproj", "{7AD28B02-46DE-470D-9C2A-5E04EA639FA4}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mediarq.Authorization", "src\Mediarq.Authorization\Mediarq.Authorization.csproj", "{04489862-B852-4141-8820-02F79E87880E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mediarq.Authorization.Tests", "Tests\Mediarq.Authorization.Tests\Mediarq.Authorization.Tests.csproj", "{ED715485-351C-4C6E-939A-D63F8E1143CA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -665,6 +669,30 @@ Global
 		{7AD28B02-46DE-470D-9C2A-5E04EA639FA4}.Release|x64.Build.0 = Release|Any CPU
 		{7AD28B02-46DE-470D-9C2A-5E04EA639FA4}.Release|x86.ActiveCfg = Release|Any CPU
 		{7AD28B02-46DE-470D-9C2A-5E04EA639FA4}.Release|x86.Build.0 = Release|Any CPU
+		{04489862-B852-4141-8820-02F79E87880E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{04489862-B852-4141-8820-02F79E87880E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{04489862-B852-4141-8820-02F79E87880E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{04489862-B852-4141-8820-02F79E87880E}.Debug|x64.Build.0 = Debug|Any CPU
+		{04489862-B852-4141-8820-02F79E87880E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{04489862-B852-4141-8820-02F79E87880E}.Debug|x86.Build.0 = Debug|Any CPU
+		{04489862-B852-4141-8820-02F79E87880E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{04489862-B852-4141-8820-02F79E87880E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{04489862-B852-4141-8820-02F79E87880E}.Release|x64.ActiveCfg = Release|Any CPU
+		{04489862-B852-4141-8820-02F79E87880E}.Release|x64.Build.0 = Release|Any CPU
+		{04489862-B852-4141-8820-02F79E87880E}.Release|x86.ActiveCfg = Release|Any CPU
+		{04489862-B852-4141-8820-02F79E87880E}.Release|x86.Build.0 = Release|Any CPU
+		{ED715485-351C-4C6E-939A-D63F8E1143CA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{ED715485-351C-4C6E-939A-D63F8E1143CA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{ED715485-351C-4C6E-939A-D63F8E1143CA}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{ED715485-351C-4C6E-939A-D63F8E1143CA}.Debug|x64.Build.0 = Debug|Any CPU
+		{ED715485-351C-4C6E-939A-D63F8E1143CA}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{ED715485-351C-4C6E-939A-D63F8E1143CA}.Debug|x86.Build.0 = Debug|Any CPU
+		{ED715485-351C-4C6E-939A-D63F8E1143CA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{ED715485-351C-4C6E-939A-D63F8E1143CA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{ED715485-351C-4C6E-939A-D63F8E1143CA}.Release|x64.ActiveCfg = Release|Any CPU
+		{ED715485-351C-4C6E-939A-D63F8E1143CA}.Release|x64.Build.0 = Release|Any CPU
+		{ED715485-351C-4C6E-939A-D63F8E1143CA}.Release|x86.ActiveCfg = Release|Any CPU
+		{ED715485-351C-4C6E-939A-D63F8E1143CA}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -716,6 +744,8 @@ Global
 		{A0E95ABE-2EF6-4FBE-BB13-DD7CCF197B61} = {241BFF49-BD9F-4E8B-855A-55286E3474C1}
 		{8E098DB4-81F0-4164-A008-0BAE29910FC3} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 		{7AD28B02-46DE-470D-9C2A-5E04EA639FA4} = {241BFF49-BD9F-4E8B-855A-55286E3474C1}
+		{04489862-B852-4141-8820-02F79E87880E} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{ED715485-351C-4C6E-939A-D63F8E1143CA} = {241BFF49-BD9F-4E8B-855A-55286E3474C1}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {A8B20815-FE51-42E4-8A6E-E12A17B80DFD}

--- a/README.md
+++ b/README.md
@@ -331,6 +331,7 @@ Mediarq ships optional, opt-in packages so the core stays dependency-free:
 | `Mediarq.Hangfire` | Enqueue/schedule a command as a Hangfire background job, dispatched through the real pipeline (`AddMediarqHangfire`) |
 | `Mediarq.Quartz` | Enqueue/schedule a command as a Quartz.NET job, dispatched through the real pipeline (`AddMediarqQuartz`) |
 | `Mediarq.HealthChecks` | `IHealthCheck` + startup validation that every command/query resolves to exactly one handler (`AddMediarqHandlerRegistrationCheck`, `AddMediarqHandlerValidationOnStartup`) |
+| `Mediarq.Authorization` | ASP.NET Core policy-based authorization as a pipeline behavior for `IAuthorizedRequest` (`AddMediarqAuthorization`) |
 
 Built into `Mediarq.Core`:
 

--- a/Tests/Mediarq.AspNetCore.Tests/ResultHttpExtensionsTests.cs
+++ b/Tests/Mediarq.AspNetCore.Tests/ResultHttpExtensionsTests.cs
@@ -24,6 +24,7 @@ public class ResultHttpExtensionsTests
     [InlineData(ErrorType.NotFound, 404)]
     [InlineData(ErrorType.Conflict, 409)]
     [InlineData(ErrorType.Unauthorized, 401)]
+    [InlineData(ErrorType.Forbidden, 403)]
     [InlineData(ErrorType.Failure, 500)]
     [InlineData(ErrorType.Problem, 500)]
     [InlineData(ErrorType.Validation, 400)]

--- a/Tests/Mediarq.Authorization.Tests/AuthorizationBehaviorTests.cs
+++ b/Tests/Mediarq.Authorization.Tests/AuthorizationBehaviorTests.cs
@@ -1,0 +1,168 @@
+using System.Security.Claims;
+using FluentAssertions;
+using Mediarq.Authorization.Tests.Fixtures;
+using Mediarq.Core.Common.Contexts;
+using Mediarq.Core.Common.Results;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Moq;
+
+namespace Mediarq.Authorization.Tests;
+
+public class AuthorizationBehaviorTests
+{
+    private static ClaimsPrincipal AuthenticatedPrincipal() =>
+        new(new ClaimsIdentity([new Claim(ClaimTypes.Name, "alice")], "TestAuth"));
+
+    private static ClaimsPrincipal UnauthenticatedPrincipal() =>
+        new(new ClaimsIdentity()); // no authenticationType -> Identity.IsAuthenticated == false
+
+    private static IHttpContextAccessor AccessorFor(ClaimsPrincipal? principal)
+    {
+        var accessor = new Mock<IHttpContextAccessor>();
+
+        if (principal is null)
+        {
+            accessor.Setup(a => a.HttpContext).Returns((HttpContext)null!);
+        }
+        else
+        {
+            var httpContext = new Mock<HttpContext>();
+            httpContext.Setup(c => c.User).Returns(principal);
+            accessor.Setup(a => a.HttpContext).Returns(httpContext.Object);
+        }
+
+        return accessor.Object;
+    }
+
+    [Fact]
+    public void IsActive_Reflects_Whether_The_Request_Type_Implements_IAuthorizedRequest()
+    {
+        var authService = new Mock<IAuthorizationService>();
+
+        new AuthorizationBehavior<PlainCommand, Result>(authService.Object, AccessorFor(null)).IsActive.Should().BeFalse();
+        new AuthorizationBehavior<AuthorizedCommand, Result<string>>(authService.Object, AccessorFor(null)).IsActive.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Handle_Returns_Unauthorized_Failure_When_No_HttpContext()
+    {
+        var authService = new Mock<IAuthorizationService>();
+        var behavior = new AuthorizationBehavior<AuthorizedCommand, Result<string>>(authService.Object, AccessorFor(null));
+        var context = new RequestContext<AuthorizedCommand, Result<string>>(new AuthorizedCommand(null), "user");
+
+        var result = await behavior.Handle(context, () => Task.FromResult(Result.Success("should not run")));
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Type.Should().Be(ErrorType.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Handle_Returns_Unauthorized_Failure_When_Principal_Is_Not_Authenticated()
+    {
+        var authService = new Mock<IAuthorizationService>();
+        var behavior = new AuthorizationBehavior<AuthorizedCommand, Result<string>>(authService.Object, AccessorFor(UnauthenticatedPrincipal()));
+        var context = new RequestContext<AuthorizedCommand, Result<string>>(new AuthorizedCommand(null), "user");
+        var handlerCalled = false;
+
+        var result = await behavior.Handle(context, () =>
+        {
+            handlerCalled = true;
+            return Task.FromResult(Result.Success("should not run"));
+        });
+
+        handlerCalled.Should().BeFalse();
+        result.Error.Type.Should().Be(ErrorType.Unauthorized);
+        authService.Verify(s => s.AuthorizeAsync(It.IsAny<ClaimsPrincipal>(), It.IsAny<object?>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_Invokes_Handler_When_Authenticated_And_No_Policy_Is_Required()
+    {
+        var authService = new Mock<IAuthorizationService>();
+        var behavior = new AuthorizationBehavior<AuthorizedCommand, Result<string>>(authService.Object, AccessorFor(AuthenticatedPrincipal()));
+        var context = new RequestContext<AuthorizedCommand, Result<string>>(new AuthorizedCommand(null), "user");
+
+        var result = await behavior.Handle(context, () => Task.FromResult(Result.Success("ok")));
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().Be("ok");
+        authService.Verify(s => s.AuthorizeAsync(It.IsAny<ClaimsPrincipal>(), It.IsAny<object?>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_Invokes_Handler_When_The_Policy_Succeeds()
+    {
+        var authService = new Mock<IAuthorizationService>();
+        authService
+            .Setup(s => s.AuthorizeAsync(It.IsAny<ClaimsPrincipal>(), It.IsAny<object?>(), "OrdersAdmin"))
+            .ReturnsAsync(AuthorizationResult.Success());
+
+        var behavior = new AuthorizationBehavior<AuthorizedCommand, Result<string>>(authService.Object, AccessorFor(AuthenticatedPrincipal()));
+        var request = new AuthorizedCommand("OrdersAdmin");
+        var context = new RequestContext<AuthorizedCommand, Result<string>>(request, "user");
+
+        var result = await behavior.Handle(context, () => Task.FromResult(Result.Success("ok")));
+
+        result.IsSuccess.Should().BeTrue();
+        authService.Verify(s => s.AuthorizeAsync(It.IsAny<ClaimsPrincipal>(), request, "OrdersAdmin"), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_Returns_Forbidden_Failure_When_The_Policy_Fails()
+    {
+        var authService = new Mock<IAuthorizationService>();
+        authService
+            .Setup(s => s.AuthorizeAsync(It.IsAny<ClaimsPrincipal>(), It.IsAny<object?>(), "OrdersAdmin"))
+            .ReturnsAsync(AuthorizationResult.Failed());
+
+        var behavior = new AuthorizationBehavior<AuthorizedCommand, Result<string>>(authService.Object, AccessorFor(AuthenticatedPrincipal()));
+        var context = new RequestContext<AuthorizedCommand, Result<string>>(new AuthorizedCommand("OrdersAdmin"), "user");
+        var handlerCalled = false;
+
+        var result = await behavior.Handle(context, () =>
+        {
+            handlerCalled = true;
+            return Task.FromResult(Result.Success("should not run"));
+        });
+
+        handlerCalled.Should().BeFalse();
+        result.IsFailure.Should().BeTrue();
+        result.Error.Type.Should().Be(ErrorType.Forbidden);
+    }
+
+    [Fact]
+    public async Task Handle_Builds_A_Result_Of_T_Failure_Via_The_Reflection_Fallback()
+    {
+        var authService = new Mock<IAuthorizationService>();
+        var behavior = new AuthorizationBehavior<AuthorizedQuery, Result<int>>(authService.Object, AccessorFor(null));
+        var context = new RequestContext<AuthorizedQuery, Result<int>>(new AuthorizedQuery(null), "user");
+
+        var result = await behavior.Handle(context, () => Task.FromResult(Result.Success(42)));
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Type.Should().Be(ErrorType.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Handle_Throws_When_TResponse_Is_Not_A_Supported_Result_Type()
+    {
+        var authService = new Mock<IAuthorizationService>();
+        var behavior = new AuthorizationBehavior<AuthorizedRawStringCommand, string>(authService.Object, AccessorFor(null));
+        var context = new RequestContext<AuthorizedRawStringCommand, string>(new AuthorizedRawStringCommand(null), "user");
+
+        var act = () => behavior.Handle(context, () => Task.FromResult("should not run"));
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void Constructor_Throws_On_Null_Arguments()
+    {
+        var authService = new Mock<IAuthorizationService>();
+        var accessor = AccessorFor(null);
+
+        ((Action)(() => new AuthorizationBehavior<PlainCommand, Result>(null!, accessor))).Should().Throw<ArgumentNullException>();
+        ((Action)(() => new AuthorizationBehavior<PlainCommand, Result>(authService.Object, null!))).Should().Throw<ArgumentNullException>();
+    }
+}

--- a/Tests/Mediarq.Authorization.Tests/AuthorizationServiceCollectionExtensionsTests.cs
+++ b/Tests/Mediarq.Authorization.Tests/AuthorizationServiceCollectionExtensionsTests.cs
@@ -1,0 +1,28 @@
+using FluentAssertions;
+using Mediarq.Core.Common.Pipeline;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Mediarq.Authorization.Tests;
+
+public class AuthorizationServiceCollectionExtensionsTests
+{
+    [Fact]
+    public void AddMediarqAuthorization_Registers_The_Behavior_And_Returns_Same_Instance()
+    {
+        var services = new ServiceCollection();
+
+        var returned = services.AddMediarqAuthorization();
+
+        returned.Should().BeSameAs(services);
+        services.Any(d => d.ServiceType == typeof(IPipelineBehavior<,>) && d.ImplementationType == typeof(AuthorizationBehavior<,>))
+            .Should().BeTrue();
+    }
+
+    [Fact]
+    public void AddMediarqAuthorization_Throws_On_Null_Services()
+    {
+        IServiceCollection services = null!;
+
+        ((Action)(() => services.AddMediarqAuthorization())).Should().Throw<ArgumentNullException>();
+    }
+}

--- a/Tests/Mediarq.Authorization.Tests/Fixtures/TestRequests.cs
+++ b/Tests/Mediarq.Authorization.Tests/Fixtures/TestRequests.cs
@@ -1,0 +1,13 @@
+using Mediarq.Core.Common.Requests.Command;
+using Mediarq.Core.Common.Requests.Query;
+using Mediarq.Core.Common.Results;
+
+namespace Mediarq.Authorization.Tests.Fixtures;
+
+public sealed record PlainCommand : ICommand<Result>;
+
+public sealed record AuthorizedCommand(string? PolicyName) : ICommand<Result<string>>, IAuthorizedRequest;
+
+public sealed record AuthorizedQuery(string? PolicyName) : IQuery<Result<int>>, IAuthorizedRequest;
+
+public sealed record AuthorizedRawStringCommand(string? PolicyName) : ICommand<string>, IAuthorizedRequest;

--- a/Tests/Mediarq.Authorization.Tests/Mediarq.Authorization.Tests.csproj
+++ b/Tests/Mediarq.Authorization.Tests/Mediarq.Authorization.Tests.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="8.7.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.10" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Mediarq.Authorization\Mediarq.Authorization.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/Tests/Mediarq.Tests/Core/Common/Results/ErrorTests.cs
+++ b/Tests/Mediarq.Tests/Core/Common/Results/ErrorTests.cs
@@ -70,4 +70,26 @@ public class ErrorTests
         problemError.Code.Should().Be("ProblemCode");
         problemError.Message.Should().Be("Problem occurred");
     }
+
+    [Fact]
+    public void Error_FactoryMethods_ShouldCreateErrorsUnauthorizedTypes()
+    {
+        // Arrange & Act
+        var unauthorizedError = ResultError.Unauthorized("UnauthorizedCode", "Authentication required");
+        // Assert
+        unauthorizedError.Type.Should().Be(ErrorType.Unauthorized);
+        unauthorizedError.Code.Should().Be("UnauthorizedCode");
+        unauthorizedError.Message.Should().Be("Authentication required");
+    }
+
+    [Fact]
+    public void Error_FactoryMethods_ShouldCreateErrorsForbiddenTypes()
+    {
+        // Arrange & Act
+        var forbiddenError = ResultError.Forbidden("ForbiddenCode", "Permission denied");
+        // Assert
+        forbiddenError.Type.Should().Be(ErrorType.Forbidden);
+        forbiddenError.Code.Should().Be("ForbiddenCode");
+        forbiddenError.Message.Should().Be("Permission denied");
+    }
 }

--- a/docs/guides/wiring-extensions.md
+++ b/docs/guides/wiring-extensions.md
@@ -179,6 +179,26 @@ builder.Services.AddMediarqHandlerValidationOnStartup(typeof(Program).Assembly);
 Throws `InvalidOperationException` once, during host startup, if any command/query has zero or more than
 one registered handler.
 
+## Mediarq.Authorization — policy-based authorization
+
+```csharp
+builder.Services.AddAuthorization();          // ASP.NET Core's own registration
+builder.Services.AddHttpContextAccessor();
+builder.Services.AddMediarqAuthorization();
+```
+Marker: `IAuthorizedRequest` (`PolicyName`). No authenticated user → `Result.Failure(ResultError.Unauthorized(...))`
+(HTTP 401 via `Mediarq.AspNetCore`); authenticated but the policy fails → `ResultError.Forbidden(...)`
+(HTTP 403). `PolicyName` can be `null` to only require authentication.
+
+```csharp
+public record DeleteOrder(Guid OrderId) : ICommand, IAuthorizedRequest
+{
+    public string? PolicyName => "OrdersAdmin";
+}
+```
+⚠️ The handler's response type must be `Result` or `Result<T>` — same constraint, same reflection-fallback
+trade-off, as the core `ValidationBehavior`'s `Result<T>` support.
+
 ## Mediarq.Polly — resilience
 
 ```csharp
@@ -236,6 +256,7 @@ builder.Services.AddMediarqCaching();
 builder.Services.AddMediarqIdempotency();
 builder.Services.AddMediarqResilience();
 builder.Services.AddMediarqDiagnostics();
+builder.Services.AddMediarqAuthorization();
 builder.Services.AddMediarqHandlerValidationOnStartup(typeof(Program).Assembly);
 ```
 

--- a/src/Mediarq.AspNetCore/README.md
+++ b/src/Mediarq.AspNetCore/README.md
@@ -24,8 +24,8 @@ public Task<IActionResult> Create(CreateOrder cmd) => mediator.Send(cmd).ToActio
 ```
 
 Status mapping: `NotFound` → 404, `Validation` → 400, `Conflict` → 409, `Unauthorized` → 401,
-otherwise 400/500 as appropriate. A validation failure renders the property errors as a ProblemDetails
-`errors` dictionary.
+`Forbidden` → 403, otherwise 400/500 as appropriate. A validation failure renders the property errors as
+a ProblemDetails `errors` dictionary.
 
 ## Learn more
 

--- a/src/Mediarq.AspNetCore/ResultHttpExtensions.cs
+++ b/src/Mediarq.AspNetCore/ResultHttpExtensions.cs
@@ -18,6 +18,7 @@ public static class ResultHttpExtensions
     {
         ErrorType.Validation => StatusCodes.Status400BadRequest,
         ErrorType.Unauthorized => StatusCodes.Status401Unauthorized,
+        ErrorType.Forbidden => StatusCodes.Status403Forbidden,
         ErrorType.NotFound => StatusCodes.Status404NotFound,
         ErrorType.Conflict => StatusCodes.Status409Conflict,
         _ => StatusCodes.Status500InternalServerError,

--- a/src/Mediarq.Authorization/AuthorizationBehavior.cs
+++ b/src/Mediarq.Authorization/AuthorizationBehavior.cs
@@ -1,0 +1,135 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Linq.Expressions;
+using System.Reflection;
+using Mediarq.Core.Common.Contexts;
+using Mediarq.Core.Common.Pipeline;
+using Mediarq.Core.Common.Requests.Abstraction;
+using Mediarq.Core.Common.Results;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+
+namespace Mediarq.Authorization;
+
+/// <summary>
+/// Pipeline behavior that runs ASP.NET Core authorization for <see cref="IAuthorizedRequest"/> requests
+/// before the handler: no authenticated user short-circuits with <see cref="ResultError.Unauthorized"/>
+/// (401), a failed policy short-circuits with <see cref="ResultError.Forbidden"/> (403). Inert for
+/// request types that are not <see cref="IAuthorizedRequest"/>.
+/// </summary>
+/// <typeparam name="TRequest">The request type.</typeparam>
+/// <typeparam name="TResponse">The response type produced by the request. Must be <see cref="Result"/> or <see cref="Result{T}"/>.</typeparam>
+public sealed class AuthorizationBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>, IConditionalPipelineBehavior
+    where TRequest : ICommandOrQuery<TResponse>
+{
+    private const string DynamicFallbackJustification =
+        "The dynamic Result<T> failure factory is only built when TResponse is a closed Result<T> not " +
+        "equal to the reflection-free Result case, which requires MakeGenericMethod.";
+
+    private static readonly bool RequestIsAuthorized = typeof(IAuthorizedRequest).IsAssignableFrom(typeof(TRequest));
+
+    // Reflection-free path for TResponse == Result; null for everything else, including Result<T>.
+    private static readonly Func<ResultError, TResponse>? FailureFactory = BuildSafeFailureFactory();
+
+    // Lazily-built, cached reflection fallback for Result<T> responses.
+    private static Func<ResultError, TResponse>? _dynamicFailureFactory;
+
+    private readonly IAuthorizationService _authorizationService;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AuthorizationBehavior{TRequest, TResponse}"/> class.
+    /// </summary>
+    /// <param name="authorizationService">Evaluates the request's <see cref="IAuthorizedRequest.PolicyName"/>.</param>
+    /// <param name="httpContextAccessor">Provides the current user's <see cref="System.Security.Claims.ClaimsPrincipal"/>.</param>
+    /// <exception cref="ArgumentNullException">Thrown if either parameter is <see langword="null"/>.</exception>
+    public AuthorizationBehavior(IAuthorizationService authorizationService, IHttpContextAccessor httpContextAccessor)
+    {
+        ArgumentNullException.ThrowIfNull(authorizationService);
+        ArgumentNullException.ThrowIfNull(httpContextAccessor);
+        _authorizationService = authorizationService;
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    /// <summary>Active only for request types that implement <see cref="IAuthorizedRequest"/>.</summary>
+    public bool IsActive => RequestIsAuthorized;
+
+    /// <inheritdoc />
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = DynamicFallbackJustification)]
+    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = DynamicFallbackJustification)]
+    public async Task<TResponse> Handle(IMutableRequestContext<TRequest, TResponse> context, Func<Task<TResponse>> handle, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(handle);
+
+        var authorized = (IAuthorizedRequest)context.Request!;
+        var principal = _httpContextAccessor.HttpContext?.User;
+
+        if (principal?.Identity?.IsAuthenticated != true)
+        {
+            return BuildFailure(ResultError.Unauthorized("Authorization.Unauthenticated", "Authentication is required to perform this operation."));
+        }
+
+        if (authorized.PolicyName is not null)
+        {
+            var authorizationResult = await _authorizationService
+                .AuthorizeAsync(principal, context.Request, authorized.PolicyName)
+                .ConfigureAwait(false);
+
+            if (!authorizationResult.Succeeded)
+            {
+                return BuildFailure(ResultError.Forbidden("Authorization.Forbidden", $"You do not have permission to perform this operation (policy '{authorized.PolicyName}')."));
+            }
+        }
+
+        return await handle().ConfigureAwait(false);
+    }
+
+    private static TResponse BuildFailure(ResultError error)
+    {
+        var factory = FailureFactory ?? ResolveDynamicFailureFactory();
+
+        if (factory is null)
+        {
+            throw new InvalidOperationException($"Authorization failed but TResponse type '{typeof(TResponse).Name}' is not a supported Result type.");
+        }
+
+        return factory(error);
+    }
+
+    private static Func<ResultError, TResponse>? BuildSafeFailureFactory()
+    {
+        if (typeof(TResponse) == typeof(Result))
+        {
+            return static error => (TResponse)(object)Result.Failure(error);
+        }
+
+        return null;
+    }
+
+    [RequiresUnreferencedCode(DynamicFallbackJustification)]
+    [RequiresDynamicCode(DynamicFallbackJustification)]
+    private static Func<ResultError, TResponse>? ResolveDynamicFailureFactory()
+    {
+        if (_dynamicFailureFactory is not null)
+        {
+            return _dynamicFailureFactory;
+        }
+
+        if (typeof(TResponse).IsGenericType && typeof(TResponse).GetGenericTypeDefinition() == typeof(Result<>))
+        {
+            Type valueType = typeof(TResponse).GetGenericArguments()[0];
+            MethodInfo method = typeof(Result)
+                .GetMethods()
+                .First(m => m.Name == nameof(Result.Failure) && m.IsGenericMethodDefinition)
+                .MakeGenericMethod(valueType);
+
+            ParameterExpression errorParam = Expression.Parameter(typeof(ResultError), "error");
+            Expression body = Expression.Convert(Expression.Call(method, errorParam), typeof(TResponse));
+
+            _dynamicFailureFactory = Expression.Lambda<Func<ResultError, TResponse>>(body, errorParam).Compile();
+            return _dynamicFailureFactory;
+        }
+
+        return null;
+    }
+}

--- a/src/Mediarq.Authorization/AuthorizationServiceCollectionExtensions.cs
+++ b/src/Mediarq.Authorization/AuthorizationServiceCollectionExtensions.cs
@@ -1,0 +1,29 @@
+using Mediarq.Core.Common.Pipeline;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Mediarq.Authorization;
+
+/// <summary>
+/// Extension methods that register the Mediarq authorization behavior.
+/// </summary>
+public static class AuthorizationServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers the <see cref="AuthorizationBehavior{TRequest, TResponse}"/> so <see cref="IAuthorizedRequest"/>
+    /// requests are authorized before their handler runs.
+    /// </summary>
+    /// <param name="services">The service collection to configure.</param>
+    /// <returns>The same service collection, enabling fluent chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="services"/> is <see langword="null"/>.</exception>
+    /// <remarks>
+    /// Requires <c>services.AddAuthorization(...)</c> and <c>services.AddHttpContextAccessor()</c> to
+    /// already be registered. Call after <c>AddMediarq</c>/<c>AddMediarqCore</c>.
+    /// </remarks>
+    public static IServiceCollection AddMediarqAuthorization(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddScoped(typeof(IPipelineBehavior<,>), typeof(AuthorizationBehavior<,>));
+        return services;
+    }
+}

--- a/src/Mediarq.Authorization/IAuthorizedRequest.cs
+++ b/src/Mediarq.Authorization/IAuthorizedRequest.cs
@@ -1,0 +1,15 @@
+namespace Mediarq.Authorization;
+
+/// <summary>
+/// Marks a request that must pass authorization before its handler runs. Requires an authenticated
+/// user; when <see cref="PolicyName"/> is set, that ASP.NET Core authorization policy must also succeed.
+/// </summary>
+public interface IAuthorizedRequest
+{
+    /// <summary>
+    /// The name of the ASP.NET Core authorization policy to evaluate (registered via
+    /// <c>services.AddAuthorization(o =&gt; o.AddPolicy(name, ...))</c>), or <see langword="null"/> to
+    /// only require an authenticated user.
+    /// </summary>
+    string? PolicyName { get; }
+}

--- a/src/Mediarq.Authorization/Mediarq.Authorization.csproj
+++ b/src/Mediarq.Authorization/Mediarq.Authorization.csproj
@@ -1,0 +1,37 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <PackageId>Mediarq.Authorization</PackageId>
+    <Version>1.0.0</Version>
+    <Authors>Nicolas Rouffart</Authors>
+    <Description>Authorization for Mediarq: an IAuthorizedRequest marker + pipeline behavior that runs ASP.NET Core policy-based authorization (IAuthorizationService) before the handler, short-circuiting into a typed Result failure (Unauthorized/Forbidden).</Description>
+    <PackageTags>mediarq;cqrs;authorization;security;dotnet</PackageTags>
+    <PackageProjectUrl>https://github.com/rouffou/mediarq</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/rouffou/mediarq</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="2.3.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Mediarq.Core\Mediarq.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+</Project>

--- a/src/Mediarq.Authorization/PublicAPI.Shipped.txt
+++ b/src/Mediarq.Authorization/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Mediarq.Authorization/PublicAPI.Unshipped.txt
+++ b/src/Mediarq.Authorization/PublicAPI.Unshipped.txt
@@ -1,0 +1,9 @@
+#nullable enable
+Mediarq.Authorization.AuthorizationBehavior<TRequest, TResponse>
+Mediarq.Authorization.AuthorizationBehavior<TRequest, TResponse>.AuthorizationBehavior(Microsoft.AspNetCore.Authorization.IAuthorizationService! authorizationService, Microsoft.AspNetCore.Http.IHttpContextAccessor! httpContextAccessor) -> void
+Mediarq.Authorization.AuthorizationBehavior<TRequest, TResponse>.Handle(Mediarq.Core.Common.Contexts.IMutableRequestContext<TRequest, TResponse>! context, System.Func<System.Threading.Tasks.Task<TResponse>!>! handle, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<TResponse>!
+Mediarq.Authorization.AuthorizationBehavior<TRequest, TResponse>.IsActive.get -> bool
+Mediarq.Authorization.AuthorizationServiceCollectionExtensions
+Mediarq.Authorization.IAuthorizedRequest
+Mediarq.Authorization.IAuthorizedRequest.PolicyName.get -> string?
+static Mediarq.Authorization.AuthorizationServiceCollectionExtensions.AddMediarqAuthorization(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!

--- a/src/Mediarq.Authorization/README.md
+++ b/src/Mediarq.Authorization/README.md
@@ -1,0 +1,50 @@
+# Mediarq.Authorization
+
+ASP.NET Core policy-based authorization as a pipeline behavior: mark a command/query as
+`IAuthorizedRequest`, and it is checked before its handler runs — no authenticated user short-circuits
+with a 401, a failed policy short-circuits with a 403, both as a typed `Result` failure your handler
+never has to think about.
+
+```bash
+dotnet add package Mediarq.Authorization
+```
+
+## Usage
+
+```csharp
+builder.Services.AddAuthorization(); // ASP.NET Core's own registration
+builder.Services.AddHttpContextAccessor();
+builder.Services.AddMediarqAuthorization();
+```
+
+```csharp
+public record DeleteOrder(Guid OrderId) : ICommand, IAuthorizedRequest
+{
+    public string? PolicyName => "OrdersAdmin";
+}
+```
+
+- `PolicyName` set → evaluated via `IAuthorizationService.AuthorizeAsync(user, request, policyName)`, so a
+  custom `IAuthorizationHandler` can inspect the request itself (e.g. checking `OrderId` ownership), not
+  just the policy name.
+- `PolicyName` set to `null` → only requires an authenticated user, no specific policy.
+- Not authenticated → `Result.Failure(ResultError.Unauthorized(...))` (maps to HTTP 401 via
+  `Mediarq.AspNetCore`).
+- Authenticated but the policy fails → `Result.Failure(ResultError.Forbidden(...))` (HTTP 403).
+- Requests that don't implement `IAuthorizedRequest` pass straight through — this behavior costs nothing
+  for them (`IConditionalPipelineBehavior.IsActive` is `false` for their closed type, so the pipeline
+  never even resolves it into the chain).
+
+## Response type
+
+The handler's response type must be `Result` or `Result<T>` — the behavior needs some way to represent an
+authorization failure as a value. `Result` is handled without reflection; `Result<T>` uses a
+one-time-per-`T` reflection fallback (cached afterwards), so it is not on the Native AOT-safe path — the
+same trade-off the core `ValidationBehavior` makes for its own `Result<T>` fallback.
+
+## Learn more
+
+[Wiring extensions](https://github.com/rouffou/mediarq/blob/main/docs/guides/wiring-extensions.md) ·
+[Full README](https://github.com/rouffou/mediarq#readme)
+
+MIT © Nicolas Rouffart

--- a/src/Mediarq.Core/Common/Results/Error.cs
+++ b/src/Mediarq.Core/Common/Results/Error.cs
@@ -85,4 +85,22 @@ public record ResultError
     /// <param name="message">A description of the problem.</param>
     /// <returns>An <see cref="ResultError"/> instance representing the problem.</returns>
     public static ResultError Problem(string code, string message) => new(code, message, ErrorType.Problem);
+
+    /// <summary>
+    /// Creates a new <see cref="ResultError"/> representing an unauthenticated actor (no user, or an
+    /// invalid/missing credential). Maps to HTTP 401.
+    /// </summary>
+    /// <param name="code">A unique error code.</param>
+    /// <param name="message">A description of the failure.</param>
+    /// <returns>An <see cref="ResultError"/> instance representing the "unauthorized" condition.</returns>
+    public static ResultError Unauthorized(string code, string message) => new(code, message, ErrorType.Unauthorized);
+
+    /// <summary>
+    /// Creates a new <see cref="ResultError"/> representing an authenticated actor who lacks permission
+    /// to perform the operation. Maps to HTTP 403.
+    /// </summary>
+    /// <param name="code">A unique error code.</param>
+    /// <param name="message">A description of the failure.</param>
+    /// <returns>An <see cref="ResultError"/> instance representing the "forbidden" condition.</returns>
+    public static ResultError Forbidden(string code, string message) => new(code, message, ErrorType.Forbidden);
 }

--- a/src/Mediarq.Core/Common/Results/ErrorType.cs
+++ b/src/Mediarq.Core/Common/Results/ErrorType.cs
@@ -46,4 +46,11 @@ public enum ErrorType
     /// to perform the requested operation.
     /// </summary>
     Unauthorized = 5,
+
+    /// <summary>
+    /// Indicates that the current user or system actor is authenticated, but does not have permission
+    /// to perform the requested operation. Distinct from <see cref="Unauthorized"/>: this is "authenticated
+    /// but not permitted" (HTTP 403), whereas <see cref="Unauthorized"/> is "not authenticated" (HTTP 401).
+    /// </summary>
+    Forbidden = 6,
 }

--- a/src/Mediarq.Core/PublicAPI.Unshipped.txt
+++ b/src/Mediarq.Core/PublicAPI.Unshipped.txt
@@ -1,3 +1,6 @@
 #nullable enable
 Mediarq.Core.Common.Pipeline.PipelineBehaviorRegistrationCache
 Mediarq.Core.Common.Pipeline.PipelineBehaviorRegistrationCache.PipelineBehaviorRegistrationCache() -> void
+Mediarq.Core.Common.Results.ErrorType.Forbidden = 6 -> Mediarq.Core.Common.Results.ErrorType
+static Mediarq.Core.Common.Results.ResultError.Forbidden(string! code, string! message) -> Mediarq.Core.Common.Results.ResultError!
+static Mediarq.Core.Common.Results.ResultError.Unauthorized(string! code, string! message) -> Mediarq.Core.Common.Results.ResultError!


### PR DESCRIPTION
## Summary
- New `Mediarq.Authorization` package: `IAuthorizedRequest` marker (`PolicyName`) + `AuthorizationBehavior<TRequest, TResponse>` pipeline behavior.
- No authenticated user (`HttpContext.User.Identity.IsAuthenticated != true`) → short-circuits with `Result.Failure(ResultError.Unauthorized(...))` — maps to HTTP 401 via `Mediarq.AspNetCore`.
- Authenticated but the named policy fails `IAuthorizationService.AuthorizeAsync(user, request, policyName)` → short-circuits with `ResultError.Forbidden(...)` — HTTP 403.
- `PolicyName == null` → only requires authentication, no specific policy evaluated.
- `IConditionalPipelineBehavior.IsActive` gates on `typeof(IAuthorizedRequest).IsAssignableFrom(typeof(TRequest))` (same pattern as `IdempotencyBehavior`), so the behavior costs nothing for request types that aren't `IAuthorizedRequest`.
- `Mediarq.Core`: `ErrorType` gains `Forbidden`; `ResultError` gains `Unauthorized(...)`/`Forbidden(...)` factories (only `Unauthorized` the enum value existed before, with no factory method — both additions purely additive/non-breaking).
- `Mediarq.AspNetCore`: `ErrorType.Forbidden` → HTTP 403 in `ToStatusCode()`.
- Response type must be `Result` or `Result<T>`, same reflection-fallback trade-off as `ValidationBehavior`'s own `Result<T>` support (reflection-free for `Result`, cached reflection for `Result<T>`, not Native-AOT-safe on that fallback path — documented in the package README).

Closes #181

## Test plan
- [x] `dotnet build Mediarq.sln -c Release` — clean, zero new warnings
- [x] `dotnet test Mediarq.sln -c Release` — full suite green, 187 in `Mediarq.Tests` (+2 for the new `ResultError` factories) and a new `Mediarq.Authorization.Tests` (11 tests: `IsActive` gating, unauthenticated → 401, policy success/failure, `Result`/`Result<T>` failure construction, unsupported response type throws, null-argument guards) plus `Mediarq.AspNetCore.Tests` (+1 for the 403 mapping)