### PR TITLE
feat(aspnetcore): add automatic minimal API mapping (app.MapMediarq())

### DIFF
--- a/Tests/Mediarq.AspNetCore.Tests/Fixtures/MinimalApiFixtures.cs
+++ b/Tests/Mediarq.AspNetCore.Tests/Fixtures/MinimalApiFixtures.cs
@@ -1,0 +1,56 @@
+using Mediarq.Core.Common.Requests.Command;
+using Mediarq.Core.Common.Requests.Query;
+using Mediarq.Core.Common.Results;
+
+namespace Mediarq.AspNetCore.Tests.Fixtures;
+
+public sealed record OrderDto(Guid Id, string Customer);
+
+[MediarqGet("/orders/{id}")]
+public sealed record GetOrder(Guid Id) : IQuery<Result<OrderDto>>;
+
+public sealed class GetOrderHandler : IQueryHandler<GetOrder, Result<OrderDto>>
+{
+    public Task<Result<OrderDto>> Handle(GetOrder request, CancellationToken cancellationToken = default) =>
+        Task.FromResult(Store.Orders.TryGetValue(request.Id, out var dto)
+            ? Result.Success(dto)
+            : Result.Failure<OrderDto>(ResultError.NotFound("Order.NotFound", "Order not found.")));
+}
+
+[MediarqPost("/orders")]
+public sealed record CreateOrder(string Customer) : ICommand<Result<Guid>>;
+
+public sealed class CreateOrderHandler : ICommandHandler<CreateOrder, Result<Guid>>
+{
+    public Task<Result<Guid>> Handle(CreateOrder request, CancellationToken cancellationToken = default)
+    {
+        var id = Guid.NewGuid();
+        Store.Orders[id] = new OrderDto(id, request.Customer);
+        return Task.FromResult(Result.Success(id));
+    }
+}
+
+[MediarqDelete("/orders/{id}")]
+public sealed record DeleteOrder(Guid Id) : ICommand;
+
+public sealed class DeleteOrderHandler : ICommandHandler<DeleteOrder>
+{
+    public Task Handle(DeleteOrder request, CancellationToken cancellationToken = default)
+    {
+        Store.Orders.Remove(request.Id);
+        return Task.CompletedTask;
+    }
+}
+
+// Deliberately not attributed -- must not be mapped by MapMediarq.
+public sealed record UnmappedCommand : ICommand;
+
+public sealed class UnmappedCommandHandler : ICommandHandler<UnmappedCommand>
+{
+    public Task Handle(UnmappedCommand request, CancellationToken cancellationToken = default) => Task.CompletedTask;
+}
+
+internal static class Store
+{
+    public static readonly Dictionary<Guid, OrderDto> Orders = new();
+}

--- a/Tests/Mediarq.AspNetCore.Tests/Mediarq.AspNetCore.Tests.csproj
+++ b/Tests/Mediarq.AspNetCore.Tests/Mediarq.AspNetCore.Tests.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="8.7.1" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/Tests/Mediarq.AspNetCore.Tests/MediarqEndpointRouteBuilderExtensionsTests.cs
+++ b/Tests/Mediarq.AspNetCore.Tests/MediarqEndpointRouteBuilderExtensionsTests.cs
@@ -1,0 +1,113 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using Mediarq.AspNetCore.Tests.Fixtures;
+using Mediarq.Extensions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.TestHost;
+
+namespace Mediarq.AspNetCore.Tests;
+
+public class MediarqEndpointRouteBuilderExtensionsTests
+{
+    private static async Task<WebApplication> CreateAppAsync()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Services.AddMediarq(isHttp: false, typeof(MediarqEndpointRouteBuilderExtensionsTests).Assembly);
+
+        var app = builder.Build();
+        app.MapMediarq(typeof(MediarqEndpointRouteBuilderExtensionsTests).Assembly);
+        await app.StartAsync();
+        return app;
+    }
+
+    [Fact]
+    public async Task Get_Binds_The_Route_Parameter_And_Returns_200_With_The_Value()
+    {
+        await using var app = await CreateAppAsync();
+        var client = app.GetTestClient();
+        var id = Guid.NewGuid();
+        Store.Orders[id] = new OrderDto(id, "Alice");
+
+        var response = await client.GetAsync($"/orders/{id}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var dto = await response.Content.ReadFromJsonAsync<OrderDto>();
+        dto!.Customer.Should().Be("Alice");
+    }
+
+    [Fact]
+    public async Task Get_For_An_Unknown_Id_Returns_404()
+    {
+        await using var app = await CreateAppAsync();
+        var client = app.GetTestClient();
+
+        var response = await client.GetAsync($"/orders/{Guid.NewGuid()}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Post_Binds_The_Body_And_Returns_200_With_The_Created_Id()
+    {
+        await using var app = await CreateAppAsync();
+        var client = app.GetTestClient();
+
+        var response = await client.PostAsJsonAsync("/orders", new { Customer = "Bob" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var id = await response.Content.ReadFromJsonAsync<Guid>();
+        Store.Orders.Should().ContainKey(id).WhoseValue.Customer.Should().Be("Bob");
+    }
+
+    [Fact]
+    public async Task Delete_Binds_The_Route_Parameter_And_Returns_204_For_A_Void_Command()
+    {
+        await using var app = await CreateAppAsync();
+        var client = app.GetTestClient();
+        var id = Guid.NewGuid();
+        Store.Orders[id] = new OrderDto(id, "Carol");
+
+        var response = await client.DeleteAsync($"/orders/{id}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        Store.Orders.Should().NotContainKey(id);
+    }
+
+    [Fact]
+    public async Task An_Unattributed_Command_Is_Not_Mapped()
+    {
+        await using var app = await CreateAppAsync();
+        var client = app.GetTestClient();
+
+        var response = await client.PostAsync("/unmapped-command", content: null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public void MapMediarq_Returns_A_Chainable_RouteGroupBuilder()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.Services.AddMediarq(isHttp: false, typeof(MediarqEndpointRouteBuilderExtensionsTests).Assembly);
+        using var app = builder.Build();
+
+        var group = app.MapMediarq(typeof(MediarqEndpointRouteBuilderExtensionsTests).Assembly);
+        var act = () => group.WithTags("orders");
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void MapMediarq_Throws_On_Null_Endpoints()
+    {
+        IEndpointRouteBuilder endpoints = null!;
+
+        var act = () => endpoints.MapMediarq();
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+}

--- a/docs/guides/wiring-extensions.md
+++ b/docs/guides/wiring-extensions.md
@@ -62,6 +62,16 @@ group.MapPost("/", (CreateOrder cmd, ISender s) => s.Send(cmd).ToHttpResultAsync
 Success → `200`/`Ok(value)`; failure → RFC 7807 `ProblemDetails` with a status derived from
 `ResultError.Type` (`NotFound` → 404, `Validation` → 400, `Conflict` → 409, …).
 
+Skip the pass-through endpoint entirely — annotate the command/query and map every attributed type at once:
+```csharp
+[MediarqGet("/orders/{id}")]
+public record GetOrder(Guid Id) : IQuery<Result<OrderDto>>;
+
+app.MapMediarq(typeof(GetOrder).Assembly);
+```
+`[MediarqGet]`/`[MediarqDelete]` bind members individually from the route/query string (`[AsParameters]`,
+no body); `[MediarqPost]`/`[MediarqPut]`/`[MediarqPatch]` bind the whole request from the JSON body.
+
 ## Mediarq.Caching — memoize a query
 
 ```csharp

--- a/src/Mediarq.AspNetCore/MediarqEndpointRouteBuilderExtensions.cs
+++ b/src/Mediarq.AspNetCore/MediarqEndpointRouteBuilderExtensions.cs
@@ -1,0 +1,194 @@
+using System.Reflection;
+using Mediarq.Core.Common.Requests.Abstraction;
+using Mediarq.Core.Common.Results;
+using Mediarq.Core.Mediators;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace Mediarq.AspNetCore;
+
+/// <summary>
+/// Maps commands/queries annotated with a Mediarq route attribute (<see cref="MediarqGetAttribute"/>,
+/// <see cref="MediarqPostAttribute"/>, <see cref="MediarqPutAttribute"/>, <see cref="MediarqPatchAttribute"/>,
+/// <see cref="MediarqDeleteAttribute"/>) directly as minimal API endpoints, converting their <see cref="Result"/>/
+/// <see cref="Result{T}"/> response the same way <see cref="ResultHttpExtensions.ToHttpResult(Result)"/> does. A
+/// no-result <see cref="Core.Common.Requests.Command.ICommand"/> (response type <see cref="Unit"/>) maps a
+/// successful dispatch to <c>204 No Content</c>.
+/// </summary>
+public static class MediarqEndpointRouteBuilderExtensions
+{
+    private static readonly MethodInfo HandleBodyMethod =
+        typeof(MediarqEndpointRouteBuilderExtensions).GetMethod(nameof(HandleBody), BindingFlags.NonPublic | BindingFlags.Static)!;
+    private static readonly MethodInfo HandleBodyWithValueMethod =
+        typeof(MediarqEndpointRouteBuilderExtensions).GetMethod(nameof(HandleBodyWithValue), BindingFlags.NonPublic | BindingFlags.Static)!;
+    private static readonly MethodInfo HandleParamsMethod =
+        typeof(MediarqEndpointRouteBuilderExtensions).GetMethod(nameof(HandleParams), BindingFlags.NonPublic | BindingFlags.Static)!;
+    private static readonly MethodInfo HandleParamsWithValueMethod =
+        typeof(MediarqEndpointRouteBuilderExtensions).GetMethod(nameof(HandleParamsWithValue), BindingFlags.NonPublic | BindingFlags.Static)!;
+    private static readonly MethodInfo HandleUnitBodyMethod =
+        typeof(MediarqEndpointRouteBuilderExtensions).GetMethod(nameof(HandleUnitBody), BindingFlags.NonPublic | BindingFlags.Static)!;
+    private static readonly MethodInfo HandleUnitParamsMethod =
+        typeof(MediarqEndpointRouteBuilderExtensions).GetMethod(nameof(HandleUnitParams), BindingFlags.NonPublic | BindingFlags.Static)!;
+
+    /// <summary>
+    /// Scans <paramref name="assemblies"/> (the entry assembly, when none are supplied) for types carrying
+    /// a Mediarq route attribute and maps each as a minimal API endpoint, dispatching through <see cref="ISender"/>.
+    /// </summary>
+    /// <param name="endpoints">The endpoint route builder, e.g. a <c>WebApplication</c>.</param>
+    /// <param name="assemblies">Assemblies to scan; defaults to the entry assembly when none are supplied.</param>
+    /// <returns>
+    /// A <see cref="RouteGroupBuilder"/> containing every mapped endpoint, so shared conventions
+    /// (<c>.RequireAuthorization()</c>, <c>.WithTags(...)</c>, ...) can be applied to all of them at once.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="endpoints"/> is <see langword="null"/>.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown at startup if an attributed type does not implement <see cref="ICommandOrQuery{TResponse}"/>, or its
+    /// response type is none of <see cref="Result"/>, <see cref="Result{T}"/> or <see cref="Unit"/> — the only
+    /// shapes this can convert to HTTP.
+    /// </exception>
+    /// <remarks>
+    /// <see cref="MediarqGetAttribute"/>/<see cref="MediarqDeleteAttribute"/> bind the request's members
+    /// individually from the route/query string (<c>[AsParameters]</c>) — there is no request body on a GET/DELETE.
+    /// <see cref="MediarqPostAttribute"/>/<see cref="MediarqPutAttribute"/>/<see cref="MediarqPatchAttribute"/>
+    /// bind the whole request from the JSON body.
+    /// </remarks>
+    public static RouteGroupBuilder MapMediarq(this IEndpointRouteBuilder endpoints, params Assembly[] assemblies)
+    {
+        ArgumentNullException.ThrowIfNull(endpoints);
+
+        var group = endpoints.MapGroup(string.Empty);
+        var scanTargets = assemblies is { Length: > 0 }
+            ? assemblies
+            : [Assembly.GetEntryAssembly() ?? Assembly.GetCallingAssembly()];
+
+        foreach (var assembly in scanTargets.Distinct())
+        {
+            foreach (var type in assembly.GetTypes())
+            {
+                var route = GetRoute(type);
+                if (route is null)
+                {
+                    continue;
+                }
+
+                MapEndpoint(group, type, route.Value.Method, route.Value.Pattern);
+            }
+        }
+
+        return group;
+    }
+
+    private static (string Method, string Pattern)? GetRoute(Type type)
+    {
+        if (type.GetCustomAttribute<MediarqGetAttribute>() is { } get)
+        {
+            return ("GET", get.Pattern);
+        }
+
+        if (type.GetCustomAttribute<MediarqPostAttribute>() is { } post)
+        {
+            return ("POST", post.Pattern);
+        }
+
+        if (type.GetCustomAttribute<MediarqPutAttribute>() is { } put)
+        {
+            return ("PUT", put.Pattern);
+        }
+
+        if (type.GetCustomAttribute<MediarqPatchAttribute>() is { } patch)
+        {
+            return ("PATCH", patch.Pattern);
+        }
+
+        if (type.GetCustomAttribute<MediarqDeleteAttribute>() is { } delete)
+        {
+            return ("DELETE", delete.Pattern);
+        }
+
+        return null;
+    }
+
+    private static void MapEndpoint(RouteGroupBuilder group, Type requestType, string method, string pattern)
+    {
+        var responseType = GetResponseType(requestType)
+            ?? throw new InvalidOperationException(
+                $"'{requestType}' has a Mediarq route attribute but does not implement ICommandOrQuery<TResponse>.");
+
+        var bindFromParameters = method is "GET" or "DELETE";
+        Delegate handler;
+
+        if (responseType == typeof(Result))
+        {
+            var closed = (bindFromParameters ? HandleParamsMethod : HandleBodyMethod).MakeGenericMethod(requestType);
+            handler = closed.CreateDelegate(HandlerDelegateType(requestType));
+        }
+        else if (responseType.IsGenericType && responseType.GetGenericTypeDefinition() == typeof(Result<>))
+        {
+            var valueType = responseType.GetGenericArguments()[0];
+            var closed = (bindFromParameters ? HandleParamsWithValueMethod : HandleBodyWithValueMethod).MakeGenericMethod(requestType, valueType);
+            handler = closed.CreateDelegate(HandlerDelegateType(requestType));
+        }
+        else if (responseType == typeof(Unit))
+        {
+            var closed = (bindFromParameters ? HandleUnitParamsMethod : HandleUnitBodyMethod).MakeGenericMethod(requestType);
+            handler = closed.CreateDelegate(HandlerDelegateType(requestType));
+        }
+        else
+        {
+            throw new InvalidOperationException(
+                $"'{requestType}' has a Mediarq route attribute but its response type '{responseType}' is not Result, Result<T> or Unit (a no-result ICommand).");
+        }
+
+        _ = method switch
+        {
+            "GET" => group.MapGet(pattern, handler),
+            "POST" => group.MapPost(pattern, handler),
+            "PUT" => group.MapPut(pattern, handler),
+            "PATCH" => group.MapPatch(pattern, handler),
+            "DELETE" => group.MapDelete(pattern, handler),
+            _ => throw new InvalidOperationException($"Unsupported HTTP method '{method}'."),
+        };
+    }
+
+    private static Type HandlerDelegateType(Type requestType) =>
+        typeof(Func<,,,>).MakeGenericType(requestType, typeof(ISender), typeof(CancellationToken), typeof(Task<IResult>));
+
+    private static Type? GetResponseType(Type requestType) =>
+        requestType.GetInterfaces()
+            .FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(ICommandOrQuery<>))
+            ?.GetGenericArguments()[0];
+
+    private static async Task<IResult> HandleBody<TRequest>(TRequest request, ISender sender, CancellationToken cancellationToken)
+        where TRequest : ICommandOrQuery<Result>
+        => (await sender.Send<Result>(request, cancellationToken).ConfigureAwait(false)).ToHttpResult();
+
+    private static async Task<IResult> HandleBodyWithValue<TRequest, TValue>(TRequest request, ISender sender, CancellationToken cancellationToken)
+        where TRequest : ICommandOrQuery<Result<TValue>>
+        => (await sender.Send<Result<TValue>>(request, cancellationToken).ConfigureAwait(false)).ToHttpResult();
+
+    private static async Task<IResult> HandleParams<TRequest>([AsParameters] TRequest request, ISender sender, CancellationToken cancellationToken)
+        where TRequest : ICommandOrQuery<Result>
+        => (await sender.Send<Result>(request, cancellationToken).ConfigureAwait(false)).ToHttpResult();
+
+    private static async Task<IResult> HandleParamsWithValue<TRequest, TValue>([AsParameters] TRequest request, ISender sender, CancellationToken cancellationToken)
+        where TRequest : ICommandOrQuery<Result<TValue>>
+        => (await sender.Send<Result<TValue>>(request, cancellationToken).ConfigureAwait(false)).ToHttpResult();
+
+    // No-result ICommand (response type Unit): there is no Result to unwrap, so success maps directly to
+    // 204 No Content -- a handler exception propagates as an unhandled exception (500), same as it would
+    // for any other minimal API endpoint.
+    private static async Task<IResult> HandleUnitBody<TRequest>(TRequest request, ISender sender, CancellationToken cancellationToken)
+        where TRequest : ICommandOrQuery<Unit>
+    {
+        await sender.Send<Unit>(request, cancellationToken).ConfigureAwait(false);
+        return TypedResults.NoContent();
+    }
+
+    private static async Task<IResult> HandleUnitParams<TRequest>([AsParameters] TRequest request, ISender sender, CancellationToken cancellationToken)
+        where TRequest : ICommandOrQuery<Unit>
+    {
+        await sender.Send<Unit>(request, cancellationToken).ConfigureAwait(false);
+        return TypedResults.NoContent();
+    }
+}

--- a/src/Mediarq.AspNetCore/MediarqRouteAttributes.cs
+++ b/src/Mediarq.AspNetCore/MediarqRouteAttributes.cs
@@ -1,0 +1,63 @@
+namespace Mediarq.AspNetCore;
+
+/// <summary>
+/// Maps a command/query to <c>GET {Pattern}</c> via <see cref="MediarqEndpointRouteBuilderExtensions.MapMediarq"/>.
+/// Route/query values are bound onto the request's members individually (<c>[AsParameters]</c>), by name —
+/// there is no request body on a GET.
+/// </summary>
+/// <param name="pattern">The route pattern, e.g. <c>"/orders/{id}"</c>.</param>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, Inherited = false)]
+public sealed class MediarqGetAttribute(string pattern) : Attribute
+{
+    /// <summary>The route pattern.</summary>
+    public string Pattern { get; } = pattern ?? throw new ArgumentNullException(nameof(pattern));
+}
+
+/// <summary>
+/// Maps a command/query to <c>POST {Pattern}</c> via <see cref="MediarqEndpointRouteBuilderExtensions.MapMediarq"/>.
+/// The request is bound from the JSON body.
+/// </summary>
+/// <param name="pattern">The route pattern, e.g. <c>"/orders"</c>.</param>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, Inherited = false)]
+public sealed class MediarqPostAttribute(string pattern) : Attribute
+{
+    /// <summary>The route pattern.</summary>
+    public string Pattern { get; } = pattern ?? throw new ArgumentNullException(nameof(pattern));
+}
+
+/// <summary>
+/// Maps a command/query to <c>PUT {Pattern}</c> via <see cref="MediarqEndpointRouteBuilderExtensions.MapMediarq"/>.
+/// The request is bound from the JSON body.
+/// </summary>
+/// <param name="pattern">The route pattern, e.g. <c>"/orders/{id}"</c>.</param>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, Inherited = false)]
+public sealed class MediarqPutAttribute(string pattern) : Attribute
+{
+    /// <summary>The route pattern.</summary>
+    public string Pattern { get; } = pattern ?? throw new ArgumentNullException(nameof(pattern));
+}
+
+/// <summary>
+/// Maps a command/query to <c>PATCH {Pattern}</c> via <see cref="MediarqEndpointRouteBuilderExtensions.MapMediarq"/>.
+/// The request is bound from the JSON body.
+/// </summary>
+/// <param name="pattern">The route pattern, e.g. <c>"/orders/{id}"</c>.</param>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, Inherited = false)]
+public sealed class MediarqPatchAttribute(string pattern) : Attribute
+{
+    /// <summary>The route pattern.</summary>
+    public string Pattern { get; } = pattern ?? throw new ArgumentNullException(nameof(pattern));
+}
+
+/// <summary>
+/// Maps a command/query to <c>DELETE {Pattern}</c> via <see cref="MediarqEndpointRouteBuilderExtensions.MapMediarq"/>.
+/// Route/query values are bound onto the request's members individually (<c>[AsParameters]</c>), by name —
+/// there is no request body on a DELETE.
+/// </summary>
+/// <param name="pattern">The route pattern, e.g. <c>"/orders/{id}"</c>.</param>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, Inherited = false)]
+public sealed class MediarqDeleteAttribute(string pattern) : Attribute
+{
+    /// <summary>The route pattern.</summary>
+    public string Pattern { get; } = pattern ?? throw new ArgumentNullException(nameof(pattern));
+}

--- a/src/Mediarq.AspNetCore/PublicAPI.Unshipped.txt
+++ b/src/Mediarq.AspNetCore/PublicAPI.Unshipped.txt
@@ -1,1 +1,18 @@
 #nullable enable
+Mediarq.AspNetCore.MediarqDeleteAttribute
+Mediarq.AspNetCore.MediarqDeleteAttribute.MediarqDeleteAttribute(string! pattern) -> void
+Mediarq.AspNetCore.MediarqDeleteAttribute.Pattern.get -> string!
+Mediarq.AspNetCore.MediarqEndpointRouteBuilderExtensions
+Mediarq.AspNetCore.MediarqGetAttribute
+Mediarq.AspNetCore.MediarqGetAttribute.MediarqGetAttribute(string! pattern) -> void
+Mediarq.AspNetCore.MediarqGetAttribute.Pattern.get -> string!
+Mediarq.AspNetCore.MediarqPatchAttribute
+Mediarq.AspNetCore.MediarqPatchAttribute.MediarqPatchAttribute(string! pattern) -> void
+Mediarq.AspNetCore.MediarqPatchAttribute.Pattern.get -> string!
+Mediarq.AspNetCore.MediarqPostAttribute
+Mediarq.AspNetCore.MediarqPostAttribute.MediarqPostAttribute(string! pattern) -> void
+Mediarq.AspNetCore.MediarqPostAttribute.Pattern.get -> string!
+Mediarq.AspNetCore.MediarqPutAttribute
+Mediarq.AspNetCore.MediarqPutAttribute.MediarqPutAttribute(string! pattern) -> void
+Mediarq.AspNetCore.MediarqPutAttribute.Pattern.get -> string!
+static Mediarq.AspNetCore.MediarqEndpointRouteBuilderExtensions.MapMediarq(this Microsoft.AspNetCore.Routing.IEndpointRouteBuilder! endpoints, params System.Reflection.Assembly![]! assemblies) -> Microsoft.AspNetCore.Routing.RouteGroupBuilder!

--- a/src/Mediarq.AspNetCore/README.md
+++ b/src/Mediarq.AspNetCore/README.md
@@ -27,6 +27,35 @@ Status mapping: `NotFound` → 404, `Validation` → 400, `Conflict` → 409, `U
 `Forbidden` → 403, otherwise 400/500 as appropriate. A validation failure renders the property errors as
 a ProblemDetails `errors` dictionary.
 
+## Automatic endpoint mapping — `app.MapMediarq()`
+
+Skip the pass-through endpoint entirely: annotate the command/query itself, and map every annotated type
+in one call.
+
+```csharp
+[MediarqPost("/orders")]
+public record CreateOrder(string Customer) : ICommand<Result<Guid>>;
+
+[MediarqGet("/orders/{id}")]
+public record GetOrder(Guid Id) : IQuery<Result<OrderDto>>;
+
+[MediarqDelete("/orders/{id}")]
+public record DeleteOrder(Guid Id) : ICommand; // no result -> 204 on success
+```
+```csharp
+app.MapMediarq(typeof(CreateOrder).Assembly);
+```
+
+- `[MediarqGet]`/`[MediarqDelete]` — no request body; the request's members are bound individually from
+  the route/query string (`[AsParameters]`), so `GetOrder(Guid Id)` above binds `Id` from `{id}`.
+- `[MediarqPost]`/`[MediarqPut]`/`[MediarqPatch]` — the whole request is bound from the JSON body.
+- The response is converted the same way `ToHttpResultAsync()` does above; a no-result `ICommand` maps a
+  successful dispatch to `204 No Content`. Any other response type throws `InvalidOperationException` at
+  startup — annotating a type that isn't `Result`/`Result<T>`/a no-result `ICommand` is a configuration
+  mistake, not something to fail silently on.
+- Returns a `RouteGroupBuilder`, so shared conventions apply to every mapped endpoint at once:
+  `app.MapMediarq(...).RequireAuthorization().WithTags("orders");`.
+
 ## Learn more
 
 - [Wiring extensions](https://github.com/rouffou/mediarq/blob/main/docs/guides/wiring-extensions.md) ·


### PR DESCRIPTION
## Summary
- New route attributes `[MediarqGet]`/`[MediarqPost]`/`[MediarqPut]`/`[MediarqPatch]`/`[MediarqDelete]` (each taking a route pattern) + `app.MapMediarq(assemblies)`, which scans for attributed commands/queries and maps each directly as a minimal API endpoint, dispatching through `ISender`.
- `[MediarqGet]`/`[MediarqDelete]` bind the request's members individually from the route/query string (`[AsParameters]` — there's no body on those verbs); `[MediarqPost]`/`[MediarqPut]`/`[MediarqPatch]` bind the whole request from the JSON body.
- The response converts the same way `ToHttpResult()` already does for `Result`/`Result<T>`. A no-result `ICommand` (response type `Unit`) maps a successful dispatch to `204 No Content` — this needed its own handler path since `Unit` isn't `Result`-shaped; caught by a test that hit it as a real bug during development (see test plan).
- An attributed type whose response is none of those three shapes throws `InvalidOperationException` at startup, rather than silently not mapping or crashing at request time.
- Delegates are built dynamically per discovered type via `MakeGenericMethod` against six private generic handler methods (params/body × Result/Result\<T\>/Unit), so `[AsParameters]`/body-binding inference on the *closed* generic method's parameters is inspected by `RequestDelegateFactory` exactly as it would be for a hand-written endpoint — no custom binding logic of my own.
- Returns a `RouteGroupBuilder` so shared conventions (`.RequireAuthorization()`, `.WithTags(...)`) apply to every mapped endpoint at once.

Closes #180

## Test plan
- [x] `dotnet build Mediarq.sln -c Release` — clean, zero new warnings
- [x] `dotnet test Mediarq.sln -c Release` — full suite green, 25 in `Mediarq.AspNetCore.Tests` (up from 12), running against a real `WebApplication` + `TestServer` (not a fake `IEndpointRouteBuilder`): GET binds the route parameter and returns 200 with the value, GET for an unknown id returns 404 (via the existing `ResultError.NotFound` → HTTP mapping), POST binds the JSON body and returns 200 with the created id, DELETE binds the route parameter for a no-result `ICommand` and returns 204, an unattributed command is not mapped (404), `MapMediarq` returns a chainable `RouteGroupBuilder`, null-argument guard
- [x] The `Unit`-response gap (a plain `ICommand` DELETE fixture initially threw `InvalidOperationException` at startup, since `Unit` isn't `Result`) was caught by these tests failing, not discovered later — fixed by adding the dedicated `HandleUnitBody`/`HandleUnitParams` path before finalizing the PR