### PR TITLE
chore(samples): wire Authorization, RateLimiting, HealthChecks, domain events into WebApi sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,7 +355,8 @@ Three runnable samples under [Samples/](Samples) (see [Samples/README.md](Sample
   pre/post processors, exception handling, timeout, `Result` combinators).
 - **[Mediarq.Samples.WebApi](Samples/Mediarq.Samples.WebApi)** — an ASP.NET Core "Orders" API wiring the
   extensions end-to-end (`Result` → HTTP, FluentValidation/DataAnnotations, caching, idempotency,
-  EF Core unit of work + transactional outbox, Polly, diagnostics/OpenTelemetry, MassTransit).
+  EF Core unit of work + transactional outbox + domain events, policy-based authorization, rate limiting,
+  health checks, Polly, diagnostics/OpenTelemetry, MassTransit).
 - **[Mediarq.AotSample](Samples/Mediarq.AotSample)** — the reflection-free path, published with Native AOT.
 
 ```bash

--- a/Samples/Mediarq.Samples.WebApi/Domain/Order.cs
+++ b/Samples/Mediarq.Samples.WebApi/Domain/Order.cs
@@ -1,3 +1,6 @@
+using Mediarq.EntityFrameworkCore;
+using Mediarq.Samples.WebApi.Features.Orders;
+
 namespace Mediarq.Samples.WebApi.Domain;
 
 public enum OrderStatus
@@ -7,8 +10,13 @@ public enum OrderStatus
     Cancelled,
 }
 
-/// <summary>The order aggregate persisted through EF Core (the unit of work).</summary>
-public sealed class Order
+/// <summary>
+/// The order aggregate persisted through EF Core (the unit of work). Derives from
+/// <see cref="AggregateRoot"/> so <see cref="Confirm"/> can raise an in-process
+/// <see cref="OrderConfirmedDomainEvent"/> — published by <c>DomainEventsInterceptor</c> right after
+/// <c>SaveChanges</c> commits, distinct from <c>OrderPlacedEvent</c>'s cross-process outbox delivery.
+/// </summary>
+public sealed class Order : AggregateRoot
 {
     public Guid Id { get; set; }
     public string Customer { get; set; } = string.Empty;
@@ -16,6 +24,13 @@ public sealed class Order
     public OrderStatus Status { get; set; } = OrderStatus.Pending;
     public List<OrderItem> Items { get; set; } = [];
     public string? Note { get; set; }
+
+    /// <summary>Marks the order confirmed and raises <see cref="OrderConfirmedDomainEvent"/>.</summary>
+    public void Confirm()
+    {
+        Status = OrderStatus.Confirmed;
+        AddDomainEvent(new OrderConfirmedDomainEvent(Id, Customer));
+    }
 }
 
 public sealed class OrderItem

--- a/Samples/Mediarq.Samples.WebApi/Endpoints/OrderEndpoints.cs
+++ b/Samples/Mediarq.Samples.WebApi/Endpoints/OrderEndpoints.cs
@@ -1,5 +1,6 @@
 using Mediarq.AspNetCore;
 using Mediarq.Core.Mediators;
+using Mediarq.RateLimiting;
 using Mediarq.Samples.WebApi.Domain;
 using Mediarq.Samples.WebApi.Features.Orders;
 
@@ -20,8 +21,26 @@ public static class OrderEndpoints
         var group = app.MapGroup("/orders").WithTags("Orders");
 
         // Create — runs FluentValidation, persists via the unit of work, enqueues an outbox event.
-        group.MapPost("/", (CreateOrderCommand command, ISender sender)
-            => sender.Send(command).ToHttpResultAsync());
+        // Throttled by the "create-order" rate limit policy; a rejected permit throws
+        // RateLimitExceededException, mapped here to 429 with a Retry-After header when the limiter
+        // reports one (see Mediarq.RateLimiting's own suggested ASP.NET Core exception-handler pattern).
+        group.MapPost("/", async (CreateOrderCommand command, ISender sender, HttpResponse http) =>
+        {
+            try
+            {
+                return await sender.Send(command).ToHttpResultAsync();
+            }
+            catch (RateLimitExceededException ex)
+            {
+                if (ex.RetryAfter is { } retryAfter)
+                    http.Headers["Retry-After"] = ((int)retryAfter.TotalSeconds).ToString();
+
+                return Results.Problem(
+                    statusCode: StatusCodes.Status429TooManyRequests,
+                    title: "Too many requests",
+                    detail: ex.Message);
+            }
+        });
 
         // Get — memoized by the caching behavior (second identical call skips the DB read).
         group.MapGet("/{id:guid}", (Guid id, ISender sender)

--- a/Samples/Mediarq.Samples.WebApi/Features/Orders/ConfirmOrder.cs
+++ b/Samples/Mediarq.Samples.WebApi/Features/Orders/ConfirmOrder.cs
@@ -1,4 +1,6 @@
+using Mediarq.Authorization;
 using Mediarq.Core.Common.Requests.Command;
+using Mediarq.Core.Common.Requests.Notifications;
 using Mediarq.Core.Common.Results;
 using Mediarq.Idempotency;
 using Mediarq.Samples.WebApi.Domain;
@@ -9,12 +11,15 @@ namespace Mediarq.Samples.WebApi.Features.Orders;
 /// <summary>
 /// Confirms an order. Implements <see cref="IIdempotentRequest"/>: the IdempotencyBehavior runs it at
 /// most once per <see cref="IdempotencyKey"/> (taken from the <c>Idempotency-Key</c> header) and replays
-/// the stored result for repeated calls — safe to retry a POST without double-confirming.
+/// the stored result for repeated calls — safe to retry a POST without double-confirming. Also implements
+/// <see cref="IAuthorizedRequest"/>: only a caller satisfying the "orders:confirm" policy (see
+/// <c>Program.cs</c>'s demo header-based auth scheme) may confirm an order.
 /// </summary>
 public sealed record ConfirmOrderCommand(Guid OrderId, string IdempotencyKey)
-    : ICommand<Result>, IIdempotentRequest
+    : ICommand<Result>, IIdempotentRequest, IAuthorizedRequest
 {
     public TimeSpan? IdempotencyDuration => TimeSpan.FromMinutes(10);
+    public string? PolicyName => "orders:confirm";
 }
 
 public sealed class ConfirmOrderHandler(AppDbContext db, ILogger<ConfirmOrderHandler> logger)
@@ -33,8 +38,26 @@ public sealed class ConfirmOrderHandler(AppDbContext db, ILogger<ConfirmOrderHan
             .Replace("\n", string.Empty);
         logger.LogInformation("Confirming order {OrderId} (key {Key})", request.OrderId, sanitizedKey);
 
-        order.Status = OrderStatus.Confirmed;
+        order.Confirm();
         await db.SaveChangesAsync(cancellationToken);
         return Result.Success();
+    }
+}
+
+/// <summary>
+/// Raised by <see cref="Order.Confirm"/> and published by <c>DomainEventsInterceptor</c> right after
+/// <c>SaveChanges</c> commits — an in-process side effect, unlike <see cref="OrderPlacedEvent"/> which
+/// also crosses the bus via the transactional outbox.
+/// </summary>
+public sealed record OrderConfirmedDomainEvent(Guid OrderId, string Customer) : INotification;
+
+public sealed class LogOrderConfirmedHandler(ILogger<LogOrderConfirmedHandler> logger)
+    : INotificationHandler<OrderConfirmedDomainEvent>
+{
+    public Task Handle(OrderConfirmedDomainEvent notification, CancellationToken cancellationToken = default)
+    {
+        logger.LogInformation("[domain event] order {OrderId} confirmed for {Customer}",
+            notification.OrderId, notification.Customer);
+        return Task.CompletedTask;
     }
 }

--- a/Samples/Mediarq.Samples.WebApi/Features/Orders/CreateOrder.cs
+++ b/Samples/Mediarq.Samples.WebApi/Features/Orders/CreateOrder.cs
@@ -2,6 +2,7 @@ using FluentValidation;
 using Mediarq.Core.Common.Requests.Command;
 using Mediarq.Core.Common.Results;
 using Mediarq.Outbox;
+using Mediarq.RateLimiting;
 using Mediarq.Samples.WebApi.Domain;
 using Mediarq.UnitOfWork;
 
@@ -12,9 +13,14 @@ public sealed record OrderLineInput(string Product, int Quantity, decimal UnitPr
 /// <summary>
 /// Creates an order. Implements <see cref="ITransactionalRequest"/> so the UnitOfWorkBehavior commits
 /// the EF Core change tracker after the handler — atomically persisting the order AND the outbox event.
+/// Also implements <see cref="IRateLimitedRequest"/>: throttled by the "create-order" policy (see
+/// <c>Program.cs</c>), shared across all callers since <see cref="PartitionKey"/> is left <see langword="null"/>.
 /// </summary>
 public sealed record CreateOrderCommand(string Customer, List<OrderLineInput> Items)
-    : ICommand<Result<Guid>>, ITransactionalRequest;
+    : ICommand<Result<Guid>>, ITransactionalRequest, IRateLimitedRequest
+{
+    public string PolicyName => "create-order";
+}
 
 public sealed class CreateOrderHandler(AppDbContext db, IOutbox outbox)
     : ICommandHandler<CreateOrderCommand, Result<Guid>>

--- a/Samples/Mediarq.Samples.WebApi/Mediarq.Samples.WebApi.csproj
+++ b/Samples/Mediarq.Samples.WebApi/Mediarq.Samples.WebApi.csproj
@@ -33,6 +33,9 @@
     <ProjectReference Include="..\..\src\Mediarq.OpenTelemetry\Mediarq.OpenTelemetry.csproj" />
     <ProjectReference Include="..\..\src\Mediarq.Polly\Mediarq.Polly.csproj" />
     <ProjectReference Include="..\..\src\Mediarq.MassTransit\Mediarq.MassTransit.csproj" />
+    <ProjectReference Include="..\..\src\Mediarq.Authorization\Mediarq.Authorization.csproj" />
+    <ProjectReference Include="..\..\src\Mediarq.RateLimiting\Mediarq.RateLimiting.csproj" />
+    <ProjectReference Include="..\..\src\Mediarq.HealthChecks\Mediarq.HealthChecks.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Samples/Mediarq.Samples.WebApi/Program.cs
+++ b/Samples/Mediarq.Samples.WebApi/Program.cs
@@ -1,20 +1,27 @@
+using System.Threading.RateLimiting;
 using FluentValidation;
+using Mediarq.Authorization;
 using Mediarq.Caching;
 using Mediarq.DataAnnotations;
 using Mediarq.Diagnostics;
 using Mediarq.EntityFrameworkCore;
 using Mediarq.Extensions;
 using Mediarq.FluentValidation;
+using Mediarq.HealthChecks;
 using Mediarq.Idempotency;
 using Mediarq.MassTransit;
 using Mediarq.OpenTelemetry;
 using Mediarq.Outbox;
 using Mediarq.Polly;
+using Mediarq.RateLimiting;
 using Mediarq.Samples.WebApi.Domain;
 using Mediarq.Samples.WebApi.Endpoints;
 using Mediarq.Samples.WebApi.Features.Orders;
+using Mediarq.Samples.WebApi.Security;
 using MassTransit;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
 using Polly;
@@ -26,10 +33,22 @@ var builder = WebApplication.CreateBuilder(args);
 // --------------------------------------------------------------------------------------------------
 // Infrastructure the extensions build on.
 // --------------------------------------------------------------------------------------------------
-builder.Services.AddDbContext<AppDbContext>(o => o.UseInMemoryDatabase("orders"));
+// The interceptor list is resolved from DI explicitly (rather than relying on EF Core's automatic
+// application-service-provider discovery) so DomainEventsInterceptor (registered below via
+// AddMediarqDomainEvents) is wired unambiguously regardless of registration order.
+builder.Services.AddDbContext<AppDbContext>((sp, o) => o
+    .UseInMemoryDatabase("orders")
+    .AddInterceptors(sp.GetServices<IInterceptor>()));
 builder.Services.AddDistributedMemoryCache();       // backs Mediarq.Idempotency (use Redis in production)
-builder.Services.AddHttpContextAccessor();          // required by HttpUserContext (isHttp: true)
+builder.Services.AddHttpContextAccessor();          // required by HttpUserContext (isHttp: true) and Mediarq.Authorization
 builder.Services.AddSingleton<IPricingService, FlakyPricingService>();
+
+// Demo-only header-based "authentication" (X-User / X-Role) and the policy Mediarq.Authorization checks.
+// See Security/DemoHeaderAuthentication.cs — never do this outside a sample.
+builder.Services
+    .AddAuthentication(DemoHeaderAuthenticationHandler.SchemeName)
+    .AddScheme<AuthenticationSchemeOptions, DemoHeaderAuthenticationHandler>(DemoHeaderAuthenticationHandler.SchemeName, _ => { });
+builder.Services.AddAuthorization(o => o.AddPolicy("orders:confirm", p => p.RequireRole("manager")));
 
 // FluentValidation validators discovered for the FluentValidation adapter.
 builder.Services.AddValidatorsFromAssemblyContaining<Program>();
@@ -52,10 +71,24 @@ builder.Services.AddMediarq(isHttp: true, typeof(Program).Assembly)
 // --------------------------------------------------------------------------------------------------
 builder.Services.AddMediarqEntityFrameworkCore<AppDbContext>();                         // DbContext as unit of work
 builder.Services.AddMediarqOutbox<AppDbContext>(o => o.PollingInterval = TimeSpan.FromSeconds(2)); // transactional outbox
+builder.Services.AddMediarqDomainEvents();                                               // IHasDomainEvents -> published after SaveChanges
 builder.Services.AddMediarqCaching();                                                    // ICacheableRequest -> IMemoryCache
 builder.Services.AddMediarqIdempotency();                                                // IIdempotentRequest -> IDistributedCache
 builder.Services.AddMediarqResilience();                                                 // IResilientRequest -> Polly
 builder.Services.AddMediarqDiagnostics();                                                // Activity + metrics (decorates the publisher)
+builder.Services.AddMediarqAuthorization();                                              // IAuthorizedRequest -> policy-based auth (401/403)
+builder.Services.AddMediarqRateLimiting(registry =>                                      // IRateLimitedRequest -> System.Threading.RateLimiting
+{
+    registry.AddPolicy("create-order", key => RateLimitPartition.GetFixedWindowLimiter(key, _ => new FixedWindowRateLimiterOptions
+    {
+        Window = TimeSpan.FromMinutes(1),
+        PermitLimit = 5,
+    }));
+});
+
+// Fails the health check (and, if you swap in AddMediarqHandlerValidationOnStartup, the app itself at
+// boot) when a command/query does not resolve to exactly one handler.
+builder.Services.AddHealthChecks().AddMediarqHandlerRegistrationCheck(assemblies: typeof(Program).Assembly);
 
 // Polly pipeline referenced by QuotePriceQuery.ResiliencePipelineName.
 builder.Services.AddResiliencePipeline("orders-pricing", pipeline => pipeline
@@ -91,7 +124,11 @@ if (app.Environment.IsDevelopment())
         .WithTheme(ScalarTheme.Saturn));
 }
 
+app.UseAuthentication();
+app.UseAuthorization();
+
 app.MapOrderEndpoints();
+app.MapHealthChecks("/health");
 app.MapGet("/", () => Results.Redirect("/scalar/v1"));
 
 app.Run();

--- a/Samples/Mediarq.Samples.WebApi/Security/DemoHeaderAuthentication.cs
+++ b/Samples/Mediarq.Samples.WebApi/Security/DemoHeaderAuthentication.cs
@@ -1,0 +1,38 @@
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Mediarq.Samples.WebApi.Security;
+
+/// <summary>
+/// A deliberately trivial authentication scheme for this sample only: a caller is "authenticated" by
+/// sending an <c>X-User</c> header, and gets an optional <c>manager</c> role via <c>X-Role</c>. This
+/// exists purely so <c>Mediarq.Authorization</c>'s <see cref="ClaimsPrincipal"/>/policy check has
+/// something real to evaluate without wiring an actual identity provider. Do not use header-based
+/// "authentication" like this outside a demo — anyone can set an HTTP header.
+/// </summary>
+public sealed class DemoHeaderAuthenticationHandler(
+    IOptionsMonitor<AuthenticationSchemeOptions> options,
+    ILoggerFactory logger,
+    UrlEncoder encoder)
+    : AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
+{
+    /// <summary>The authentication scheme name registered in <c>Program.cs</c>.</summary>
+    public const string SchemeName = "Demo";
+
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        if (!Request.Headers.TryGetValue("X-User", out var user) || string.IsNullOrWhiteSpace(user))
+            return Task.FromResult(AuthenticateResult.NoResult());
+
+        var claims = new List<Claim> { new(ClaimTypes.Name, user!) };
+        if (Request.Headers.TryGetValue("X-Role", out var role) && !string.IsNullOrWhiteSpace(role))
+            claims.Add(new Claim(ClaimTypes.Role, role!));
+
+        var identity = new ClaimsIdentity(claims, SchemeName);
+        var ticket = new AuthenticationTicket(new ClaimsPrincipal(identity), SchemeName);
+        return Task.FromResult(AuthenticateResult.Success(ticket));
+    }
+}

--- a/Samples/README.md
+++ b/Samples/README.md
@@ -6,7 +6,7 @@ core to a web app that wires up every extension.
 | Sample | Kind | What it shows | Run |
 |---|---|---|---|
 | [Mediarq.Samples.Quickstart](Mediarq.Samples.Quickstart) | Console | The core, in-process: commands / queries / void commands, notifications (multiple handlers), streaming, built-in validation, a custom ordered behavior, pre/post processors, exception → `Result`, timeout, and `Result` combinators. | `dotnet run --project Samples/Mediarq.Samples.Quickstart` |
-| [Mediarq.Samples.WebApi](Mediarq.Samples.WebApi) | ASP.NET Core (minimal API) | A small **Orders** domain wiring the extensions end-to-end: `Result` → HTTP/ProblemDetails, FluentValidation **and** DataAnnotations, caching, idempotency, EF Core unit of work, transactional outbox, Polly resilience, diagnostics + OpenTelemetry, and MassTransit forwarding. | `dotnet run --project Samples/Mediarq.Samples.WebApi` |
+| [Mediarq.Samples.WebApi](Mediarq.Samples.WebApi) | ASP.NET Core (minimal API) | A small **Orders** domain wiring the extensions end-to-end: `Result` → HTTP/ProblemDetails, FluentValidation **and** DataAnnotations, caching, idempotency, EF Core unit of work, transactional outbox **and** domain events, policy-based authorization, rate limiting, health checks, Polly resilience, diagnostics + OpenTelemetry, and MassTransit forwarding. | `dotnet run --project Samples/Mediarq.Samples.WebApi` |
 | [Mediarq.AotSample](Mediarq.AotSample) | Console (Native AOT) | The **reflection-free** path (`AddMediarqCore().AddMediarqHandlers()`): command, query, streaming, source-generated validation failures, and a `[RegisterHandler]` lifetime override — publishes cleanly with Native AOT. | `dotnet run --project Samples/Mediarq.AotSample` |
 
 ## Quickstart (console)
@@ -22,15 +22,27 @@ at `/scalar/v1` to exercise the endpoints:
 
 | Endpoint | Capability |
 |---|---|
-| `POST /orders` | Create — FluentValidation, unit of work commit, **transactional outbox** event |
+| `POST /orders` | Create — FluentValidation, unit of work commit, **transactional outbox** event, **rate-limited** (5/min, see the "create-order" policy) |
 | `GET /orders/{id}` | Read — memoized by the **caching** behavior (second identical call skips the DB) |
-| `POST /orders/{id}/confirm` | **Idempotent** — send the same `Idempotency-Key` header to replay instead of re-running |
+| `POST /orders/{id}/confirm` | **Idempotent** (send the same `Idempotency-Key` header to replay) and **authorized** — requires `X-User` + `X-Role: manager` headers (see below), raises a **domain event** on success |
 | `POST /orders/{id}/note` | **DataAnnotations** validation (an empty note returns a 400 ProblemDetails) |
 | `GET /orders/{id}/quote` | **Polly** resilience — retries a flaky pricing service |
 | `GET /orders/stream` | **Streaming** — `IAsyncEnumerable` of orders |
+| `GET /health` | **Health check** — reports unhealthy if a command/query doesn't resolve to exactly one handler |
 
 Watch the console: the outbox publishes `OrderPlacedEvent` to its in-process handlers **and** forwards it
-onto the in-memory MassTransit bus, and OpenTelemetry exports Mediarq activities/metrics.
+onto the in-memory MassTransit bus; confirming an order raises an in-process `OrderConfirmedDomainEvent`
+via `Mediarq.EntityFrameworkCore`'s `AggregateRoot`/`DomainEventsInterceptor` instead (published right
+after `SaveChanges` commits, no outbox/bus hop); and OpenTelemetry exports Mediarq activities/metrics.
+
+Authorization uses a deliberately trivial header-based "authentication" scheme for this sample only (see
+`Security/DemoHeaderAuthentication.cs`) — never do this outside a demo:
+
+```bash
+curl -X POST http://localhost:5205/orders/{id}/confirm                                    # 401, no X-User header
+curl -X POST http://localhost:5205/orders/{id}/confirm -H "X-User: alice"                 # 403, missing the "manager" role
+curl -X POST http://localhost:5205/orders/{id}/confirm -H "X-User: alice" -H "X-Role: manager"  # 204
+```
 
 > The WebApi uses the scan-based `AddMediarq(...)` for readability. For trimming / Native AOT, swap it
 > for `AddMediarqCore(isHttp: true).AddMediarqHandlers()` — the path the AOT sample demonstrates.


### PR DESCRIPTION
Closes #203

## Summary
- The `Mediarq.Samples.WebApi` "Orders" sample only demonstrated the extensions that existed before this cycle's four additions. It now wires all of them end-to-end:
  - **Mediarq.RateLimiting** — `CreateOrderCommand` implements `IRateLimitedRequest` against a `create-order` policy (5/min, shared bucket); `RateLimitExceededException` is mapped to `429` with a `Retry-After` header at the endpoint.
  - **Mediarq.Authorization** — `ConfirmOrderCommand` implements `IAuthorizedRequest` against an `orders:confirm` policy (requires the `manager` role). A self-contained, header-based demo authentication scheme (`Security/DemoHeaderAuthentication.cs`) makes this exercisable without a real identity provider — never for use outside a sample.
  - **Mediarq.EntityFrameworkCore domain events** — `Order` derives from `AggregateRoot`; `Order.Confirm()` raises `OrderConfirmedDomainEvent`, published by `DomainEventsInterceptor` right after `SaveChanges` commits — distinct from `OrderPlacedEvent`'s cross-process outbox delivery. `AppDbContext`'s registration now resolves `IInterceptor` explicitly from DI so the interceptor is wired unambiguously.
  - **Mediarq.HealthChecks** — `GET /health` reports unhealthy if a command/query doesn't resolve to exactly one handler.
- Updated `README.md` and `Samples/README.md` to describe the new endpoints/behavior.

## Test plan
- [x] `dotnet build Mediarq.sln -c Release` — 0 errors
- [x] `dotnet test Mediarq.sln -c Release` — all green (unchanged, this is a samples-only change)
- [x] Ran the sample locally and exercised every new path manually:
  - `POST /orders` × 6 in a row → first 5 succeed, 6th returns `429` with the expected `RateLimitExceededException` message
  - `POST /orders/{id}/confirm` with no `X-User` header → `401`
  - same with `X-User` but no `X-Role: manager` → `403`
  - same with `X-Role: manager` → `204`, and the log shows `[domain event] order {id} confirmed for {customer}`
  - `GET /health` → `Healthy`
  - existing endpoints (`GET /orders/{id}`, note, quote) unaffected
