### PR TITLE
feat(grpc): add Mediarq.Grpc package for direct point-to-point notification transport

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,7 @@ jobs:
           dotnet pack src/Mediarq.AzureServiceBus/Mediarq.AzureServiceBus.csproj --no-build -c Release -p:Version=${{ steps.version.outputs.version }} -o ./artifacts
           dotnet pack src/Mediarq.RabbitMQ/Mediarq.RabbitMQ.csproj --no-build -c Release -p:Version=${{ steps.version.outputs.version }} -o ./artifacts
           dotnet pack src/Mediarq.Aspire/Mediarq.Aspire.csproj --no-build -c Release -p:Version=${{ steps.version.outputs.version }} -o ./artifacts
+          dotnet pack src/Mediarq.Grpc/Mediarq.Grpc.csproj --no-build -c Release -p:Version=${{ steps.version.outputs.version }} -o ./artifacts
 
       - name: NuGet login (trusted publishing)
         id: login

--- a/Mediarq.sln
+++ b/Mediarq.sln
@@ -126,6 +126,7 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mediarq.AzureServiceBus", "src\Mediarq.AzureServiceBus\Mediarq.AzureServiceBus.csproj", "{6A4CD753-968F-4FAF-BF3A-9127D833DDA0}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mediarq.AzureServiceBus.Tests", "Tests\Mediarq.AzureServiceBus.Tests\Mediarq.AzureServiceBus.Tests.csproj", "{6A8DA57B-E276-40BB-B592-8618A1FF8E25}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mediarq.RabbitMQ", "src\Mediarq.RabbitMQ\Mediarq.RabbitMQ.csproj", "{19CBC6E0-6D95-4851-A87E-2D9C0FA32BC2}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mediarq.RabbitMQ.Tests", "Tests\Mediarq.RabbitMQ.Tests\Mediarq.RabbitMQ.Tests.csproj", "{83C9A7C2-066C-45C5-9204-C0B596690EAE}"
@@ -133,6 +134,10 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mediarq.Aspire", "src\Mediarq.Aspire\Mediarq.Aspire.csproj", "{44BBBC3A-899A-4DF5-AD83-BD3757B6DE31}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mediarq.Aspire.Tests", "Tests\Mediarq.Aspire.Tests\Mediarq.Aspire.Tests.csproj", "{6BAD21D6-3276-44FE-B133-F31E45191D77}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mediarq.Grpc", "src\Mediarq.Grpc\Mediarq.Grpc.csproj", "{4D7A682B-0A08-44C3-B3EF-E587678F7398}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mediarq.Grpc.Tests", "Tests\Mediarq.Grpc.Tests\Mediarq.Grpc.Tests.csproj", "{D4ADFA93-3791-4D7D-A428-AECBA862688C}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -888,6 +893,30 @@ Global
 		{6BAD21D6-3276-44FE-B133-F31E45191D77}.Release|x64.Build.0 = Release|Any CPU
 		{6BAD21D6-3276-44FE-B133-F31E45191D77}.Release|x86.ActiveCfg = Release|Any CPU
 		{6BAD21D6-3276-44FE-B133-F31E45191D77}.Release|x86.Build.0 = Release|Any CPU
+		{4D7A682B-0A08-44C3-B3EF-E587678F7398}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4D7A682B-0A08-44C3-B3EF-E587678F7398}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4D7A682B-0A08-44C3-B3EF-E587678F7398}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{4D7A682B-0A08-44C3-B3EF-E587678F7398}.Debug|x64.Build.0 = Debug|Any CPU
+		{4D7A682B-0A08-44C3-B3EF-E587678F7398}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4D7A682B-0A08-44C3-B3EF-E587678F7398}.Debug|x86.Build.0 = Debug|Any CPU
+		{4D7A682B-0A08-44C3-B3EF-E587678F7398}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4D7A682B-0A08-44C3-B3EF-E587678F7398}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4D7A682B-0A08-44C3-B3EF-E587678F7398}.Release|x64.ActiveCfg = Release|Any CPU
+		{4D7A682B-0A08-44C3-B3EF-E587678F7398}.Release|x64.Build.0 = Release|Any CPU
+		{4D7A682B-0A08-44C3-B3EF-E587678F7398}.Release|x86.ActiveCfg = Release|Any CPU
+		{4D7A682B-0A08-44C3-B3EF-E587678F7398}.Release|x86.Build.0 = Release|Any CPU
+		{D4ADFA93-3791-4D7D-A428-AECBA862688C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D4ADFA93-3791-4D7D-A428-AECBA862688C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D4ADFA93-3791-4D7D-A428-AECBA862688C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D4ADFA93-3791-4D7D-A428-AECBA862688C}.Debug|x64.Build.0 = Debug|Any CPU
+		{D4ADFA93-3791-4D7D-A428-AECBA862688C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D4ADFA93-3791-4D7D-A428-AECBA862688C}.Debug|x86.Build.0 = Debug|Any CPU
+		{D4ADFA93-3791-4D7D-A428-AECBA862688C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D4ADFA93-3791-4D7D-A428-AECBA862688C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D4ADFA93-3791-4D7D-A428-AECBA862688C}.Release|x64.ActiveCfg = Release|Any CPU
+		{D4ADFA93-3791-4D7D-A428-AECBA862688C}.Release|x64.Build.0 = Release|Any CPU
+		{D4ADFA93-3791-4D7D-A428-AECBA862688C}.Release|x86.ActiveCfg = Release|Any CPU
+		{D4ADFA93-3791-4D7D-A428-AECBA862688C}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -955,6 +984,8 @@ Global
 		{83C9A7C2-066C-45C5-9204-C0B596690EAE} = {241BFF49-BD9F-4E8B-855A-55286E3474C1}
 		{44BBBC3A-899A-4DF5-AD83-BD3757B6DE31} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 		{6BAD21D6-3276-44FE-B133-F31E45191D77} = {241BFF49-BD9F-4E8B-855A-55286E3474C1}
+		{4D7A682B-0A08-44C3-B3EF-E587678F7398} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{D4ADFA93-3791-4D7D-A428-AECBA862688C} = {241BFF49-BD9F-4E8B-855A-55286E3474C1}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {A8B20815-FE51-42E4-8A6E-E12A17B80DFD}

--- a/README.md
+++ b/README.md
@@ -363,6 +363,7 @@ Mediarq ships optional, opt-in packages so the core stays dependency-free:
 | `Mediarq.AzureServiceBus` | A lightweight, direct Azure Service Bus bridge: publish `IAzureServiceBusEvent` notifications (`AddMediarqAzureServiceBusPublisher`) and consume them back into the pipeline via a background service (`AddMediarqAzureServiceBusSubscriber`) |
 | `Mediarq.RabbitMQ` | A lightweight, direct RabbitMQ bridge: publish `IRabbitMqEvent` notifications (`AddMediarqRabbitMqPublisher`) and consume them back into the pipeline via a background service (`AddMediarqRabbitMqSubscriber`) |
 | `Mediarq.Aspire` | .NET Aspire `ServiceDefaults` integration: wires Mediarq's OpenTelemetry instrumentation and handler-registration health check into your own `ServiceDefaults` project (`AddMediarqServiceDefaults`) |
+| `Mediarq.Grpc` | Direct point-to-point gRPC transport: publish `IGrpcNotificationEvent` notifications to another service's endpoint (`AddMediarqGrpcPublisher`) and receive them back into the pipeline via a shared gRPC service (`AddMediarqGrpcSubscriptions` + `MapMediarqGrpcSubscription`) — ships its own compiled Protobuf contract, no `protoc` needed downstream |
 
 Built into `Mediarq.Core`:
 

--- a/Tests/Mediarq.Grpc.Tests/Fixtures/LiveOrderPlaced.cs
+++ b/Tests/Mediarq.Grpc.Tests/Fixtures/LiveOrderPlaced.cs
@@ -1,0 +1,9 @@
+namespace Mediarq.Grpc.Tests.Fixtures;
+
+// A separate fixture (rather than reusing OrderPlaced) because ServiceAddress must point at a real,
+// locally-bound Kestrel endpoint for the one test that exercises the actual client-to-server socket path
+// (GrpcNotificationForwarderEndToEndTests) — every other test only needs a well-formed address string.
+public sealed record LiveOrderPlaced(Guid OrderId, string Customer) : IGrpcNotificationEvent
+{
+    public static string ServiceAddress => "http://127.0.0.1:57123";
+}

--- a/Tests/Mediarq.Grpc.Tests/Fixtures/TestEvents.cs
+++ b/Tests/Mediarq.Grpc.Tests/Fixtures/TestEvents.cs
@@ -1,0 +1,6 @@
+namespace Mediarq.Grpc.Tests.Fixtures;
+
+public sealed record OrderPlaced(Guid OrderId, string Customer) : IGrpcNotificationEvent
+{
+    public static string ServiceAddress => "https://order-service:5001";
+}

--- a/Tests/Mediarq.Grpc.Tests/GrpcChannelCacheTests.cs
+++ b/Tests/Mediarq.Grpc.Tests/GrpcChannelCacheTests.cs
@@ -1,0 +1,38 @@
+using FluentAssertions;
+
+namespace Mediarq.Grpc.Tests;
+
+public class GrpcChannelCacheTests
+{
+    [Fact]
+    public void GetOrCreate_Returns_The_Same_Channel_For_The_Same_Address()
+    {
+        using var cache = new GrpcChannelCache();
+
+        var first = cache.GetOrCreate("https://order-service:5001");
+        var second = cache.GetOrCreate("https://order-service:5001");
+
+        second.Should().BeSameAs(first);
+    }
+
+    [Fact]
+    public void GetOrCreate_Returns_Different_Channels_For_Different_Addresses()
+    {
+        using var cache = new GrpcChannelCache();
+
+        var first = cache.GetOrCreate("https://order-service:5001");
+        var second = cache.GetOrCreate("https://billing-service:5002");
+
+        second.Should().NotBeSameAs(first);
+    }
+
+    [Fact]
+    public void Dispose_Does_Not_Throw_When_No_Channel_Was_Ever_Created()
+    {
+        var cache = new GrpcChannelCache();
+
+        var act = cache.Dispose;
+
+        act.Should().NotThrow();
+    }
+}

--- a/Tests/Mediarq.Grpc.Tests/GrpcEndpointRouteBuilderExtensionsTests.cs
+++ b/Tests/Mediarq.Grpc.Tests/GrpcEndpointRouteBuilderExtensionsTests.cs
@@ -1,0 +1,97 @@
+using FluentAssertions;
+using Google.Protobuf;
+using Grpc.Core;
+using Grpc.Net.Client;
+using Mediarq.Core.Mediators;
+using Mediarq.Grpc.Contracts;
+using Mediarq.Grpc.Tests.Fixtures;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+
+namespace Mediarq.Grpc.Tests;
+
+public class GrpcEndpointRouteBuilderExtensionsTests
+{
+    private static async Task<(WebApplication App, Mock<IPublisher> Publisher)> CreateAppAsync()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        var publisher = new Mock<IPublisher>();
+        builder.Services.AddSingleton(publisher.Object);
+        builder.Services.AddMediarqGrpcSubscriptions();
+
+        var app = builder.Build();
+        app.MapMediarqGrpcNotificationService();
+        app.MapMediarqGrpcSubscription<OrderPlaced>();
+        await app.StartAsync();
+        return (app, publisher);
+    }
+
+    [Fact]
+    public void MapMediarqGrpcNotificationService_Throws_When_App_Is_Null()
+    {
+        Microsoft.AspNetCore.Routing.IEndpointRouteBuilder app = null!;
+
+        var act = () => app.MapMediarqGrpcNotificationService();
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void MapMediarqGrpcSubscription_Throws_When_App_Is_Null()
+    {
+        Microsoft.AspNetCore.Routing.IEndpointRouteBuilder app = null!;
+
+        var act = () => app.MapMediarqGrpcSubscription<OrderPlaced>();
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task Publish_Over_The_Real_gRPC_Endpoint_Republishes_Through_IPublisher()
+    {
+        var (app, publisher) = await CreateAppAsync();
+        await using var _1 = app;
+
+        using var channel = GrpcChannel.ForAddress(
+            "http://localhost",
+            new GrpcChannelOptions { HttpHandler = app.GetTestServer().CreateHandler() });
+        var client = new NotificationService.NotificationServiceClient(channel);
+        var orderId = Guid.NewGuid();
+
+        var envelope = new NotificationEnvelope
+        {
+            TypeName = typeof(OrderPlaced).FullName!,
+            Payload = ByteString.CopyFrom(
+                System.Text.Json.JsonSerializer.SerializeToUtf8Bytes(new OrderPlaced(orderId, "Alice"))),
+        };
+
+        var ack = await client.PublishAsync(envelope);
+
+        ack.Accepted.Should().BeTrue();
+        publisher.Verify(
+            p => p.Publish(It.Is<OrderPlaced>(n => n.OrderId == orderId && n.Customer == "Alice"), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Publish_Over_The_Real_gRPC_Endpoint_Fails_NotFound_For_An_Unsubscribed_Type()
+    {
+        var (app, _) = await CreateAppAsync();
+        await using var _1 = app;
+
+        using var channel = GrpcChannel.ForAddress(
+            "http://localhost",
+            new GrpcChannelOptions { HttpHandler = app.GetTestServer().CreateHandler() });
+        var client = new NotificationService.NotificationServiceClient(channel);
+
+        var envelope = new NotificationEnvelope { TypeName = "Unregistered.Type", Payload = ByteString.Empty };
+
+        var act = async () => await client.PublishAsync(envelope);
+
+        var exception = await act.Should().ThrowAsync<RpcException>();
+        exception.Which.StatusCode.Should().Be(StatusCode.NotFound);
+    }
+}

--- a/Tests/Mediarq.Grpc.Tests/GrpcNotificationForwarderEndToEndTests.cs
+++ b/Tests/Mediarq.Grpc.Tests/GrpcNotificationForwarderEndToEndTests.cs
@@ -1,0 +1,47 @@
+using FluentAssertions;
+using Mediarq.Core.Common.Requests.Notifications;
+using Mediarq.Core.Mediators;
+using Mediarq.Grpc.Tests.Fixtures;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+
+namespace Mediarq.Grpc.Tests;
+
+// GrpcChannelCache always dials a real address via GrpcChannel.ForAddress (no injectable HttpMessageHandler
+// hook, unlike raw HttpClient-based packages), so unlike the TestServer-based round trip in
+// GrpcEndpointRouteBuilderExtensionsTests, exercising the *forwarder* end to end needs a real bound
+// socket — this is the one test in the suite that does so, over plain HTTP/2 (h2c) on a fixed loopback
+// port matching LiveOrderPlaced.ServiceAddress.
+public class GrpcNotificationForwarderEndToEndTests
+{
+    [Fact]
+    public async Task Forwarder_Delivers_Over_A_Real_Socket_To_A_Live_Kestrel_Server()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.ConfigureKestrel(options =>
+            options.ListenLocalhost(57123, listenOptions => listenOptions.Protocols = HttpProtocols.Http2));
+        var publisher = new Mock<IPublisher>();
+        builder.Services.AddSingleton(publisher.Object);
+        builder.Services.AddMediarqGrpcSubscriptions();
+
+        await using var app = builder.Build();
+        app.MapMediarqGrpcNotificationService();
+        app.MapMediarqGrpcSubscription<LiveOrderPlaced>();
+        await app.StartAsync();
+
+        var services = new ServiceCollection();
+        services.AddMediarqGrpcPublisher<LiveOrderPlaced>();
+        await using var provider = services.BuildServiceProvider();
+        var forwarder = provider.GetRequiredService<INotificationHandler<LiveOrderPlaced>>();
+
+        var orderId = Guid.NewGuid();
+        await forwarder.Handle(new LiveOrderPlaced(orderId, "Alice"));
+
+        publisher.Verify(
+            p => p.Publish(It.Is<LiveOrderPlaced>(n => n.OrderId == orderId && n.Customer == "Alice"), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+}

--- a/Tests/Mediarq.Grpc.Tests/GrpcNotificationSubscriptionRegistryTests.cs
+++ b/Tests/Mediarq.Grpc.Tests/GrpcNotificationSubscriptionRegistryTests.cs
@@ -1,0 +1,56 @@
+using System.Text.Json;
+using FluentAssertions;
+using Google.Protobuf;
+using Mediarq.Core.Mediators;
+using Mediarq.Grpc.Tests.Fixtures;
+using Moq;
+
+namespace Mediarq.Grpc.Tests;
+
+public class GrpcNotificationSubscriptionRegistryTests
+{
+    [Fact]
+    public void TryGetHandler_Returns_False_For_An_Unregistered_Type()
+    {
+        var registry = new GrpcNotificationSubscriptionRegistry();
+
+        var found = registry.TryGetHandler("Unknown.Type", out _);
+
+        found.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task TryGetHandler_Returns_A_Delegate_That_Deserializes_And_Publishes()
+    {
+        var registry = new GrpcNotificationSubscriptionRegistry();
+        registry.Add<OrderPlaced>();
+
+        var found = registry.TryGetHandler(typeof(OrderPlaced).FullName!, out var handler);
+        found.Should().BeTrue();
+
+        var orderId = Guid.NewGuid();
+        var payload = ByteString.CopyFrom(JsonSerializer.SerializeToUtf8Bytes(new OrderPlaced(orderId, "Alice")));
+        var publisher = new Mock<IPublisher>();
+
+        await handler(payload, publisher.Object, CancellationToken.None);
+
+        publisher.Verify(
+            p => p.Publish(It.Is<OrderPlaced>(n => n.OrderId == orderId && n.Customer == "Alice"), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task TryGetHandler_Delegate_Throws_When_The_Payload_Deserializes_To_Null()
+    {
+        var registry = new GrpcNotificationSubscriptionRegistry();
+        registry.Add<OrderPlaced>();
+        registry.TryGetHandler(typeof(OrderPlaced).FullName!, out var handler);
+
+        var nullPayload = ByteString.CopyFromUtf8("null");
+        var publisher = new Mock<IPublisher>();
+
+        var act = async () => await handler(nullPayload, publisher.Object, CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+}

--- a/Tests/Mediarq.Grpc.Tests/GrpcServiceCollectionExtensionsTests.cs
+++ b/Tests/Mediarq.Grpc.Tests/GrpcServiceCollectionExtensionsTests.cs
@@ -1,0 +1,66 @@
+using FluentAssertions;
+using Mediarq.Core.Common.Requests.Notifications;
+using Mediarq.Grpc.Tests.Fixtures;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Mediarq.Grpc.Tests;
+
+public class GrpcServiceCollectionExtensionsTests
+{
+    [Fact]
+    public void AddMediarqGrpcPublisher_Registers_The_Forwarder()
+    {
+        var services = new ServiceCollection();
+
+        services.AddMediarqGrpcPublisher<OrderPlaced>();
+        using var provider = services.BuildServiceProvider();
+
+        provider.GetRequiredService<INotificationHandler<OrderPlaced>>()
+            .Should().BeOfType<GrpcNotificationForwarder<OrderPlaced>>();
+    }
+
+    [Fact]
+    public void AddMediarqGrpcPublisher_Registers_The_Channel_Cache_As_A_Singleton()
+    {
+        var services = new ServiceCollection();
+
+        services.AddMediarqGrpcPublisher<OrderPlaced>();
+        using var provider = services.BuildServiceProvider();
+
+        var first = provider.GetRequiredService<GrpcChannelCache>();
+        var second = provider.GetRequiredService<GrpcChannelCache>();
+
+        second.Should().BeSameAs(first);
+    }
+
+    [Fact]
+    public void AddMediarqGrpcPublisher_Throws_When_Services_Is_Null()
+    {
+        IServiceCollection services = null!;
+
+        var act = () => services.AddMediarqGrpcPublisher<OrderPlaced>();
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void AddMediarqGrpcSubscriptions_Registers_The_Registry()
+    {
+        var services = new ServiceCollection();
+
+        services.AddMediarqGrpcSubscriptions();
+        using var provider = services.BuildServiceProvider();
+
+        provider.GetRequiredService<GrpcNotificationSubscriptionRegistry>().Should().NotBeNull();
+    }
+
+    [Fact]
+    public void AddMediarqGrpcSubscriptions_Throws_When_Services_Is_Null()
+    {
+        IServiceCollection services = null!;
+
+        var act = () => services.AddMediarqGrpcSubscriptions();
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+}

--- a/Tests/Mediarq.Grpc.Tests/Mediarq.Grpc.Tests.csproj
+++ b/Tests/Mediarq.Grpc.Tests/Mediarq.Grpc.Tests.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="8.7.1" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Mediarq.Grpc\Mediarq.Grpc.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/Tests/Mediarq.Grpc.Tests/MediarqGrpcNotificationServiceTests.cs
+++ b/Tests/Mediarq.Grpc.Tests/MediarqGrpcNotificationServiceTests.cs
@@ -1,0 +1,70 @@
+using System.Text.Json;
+using FluentAssertions;
+using Google.Protobuf;
+using Grpc.Core;
+using Mediarq.Core.Mediators;
+using Mediarq.Grpc.Contracts;
+using Mediarq.Grpc.Tests.Fixtures;
+using Moq;
+
+namespace Mediarq.Grpc.Tests;
+
+public class MediarqGrpcNotificationServiceTests
+{
+    [Fact]
+    public async Task Publish_Republishes_A_Known_Notification_Type_And_Returns_Accepted()
+    {
+        var registry = new GrpcNotificationSubscriptionRegistry();
+        registry.Add<OrderPlaced>();
+        var publisher = new Mock<IPublisher>();
+        var service = new MediarqGrpcNotificationService(registry, publisher.Object);
+
+        var orderId = Guid.NewGuid();
+        var envelope = new NotificationEnvelope
+        {
+            TypeName = typeof(OrderPlaced).FullName!,
+            Payload = ByteString.CopyFrom(JsonSerializer.SerializeToUtf8Bytes(new OrderPlaced(orderId, "Alice"))),
+        };
+
+        var ack = await service.Publish(envelope, TestServerCallContext.Create());
+
+        ack.Accepted.Should().BeTrue();
+        publisher.Verify(
+            p => p.Publish(It.Is<OrderPlaced>(n => n.OrderId == orderId && n.Customer == "Alice"), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Publish_Throws_NotFound_For_An_Unregistered_Notification_Type()
+    {
+        var registry = new GrpcNotificationSubscriptionRegistry();
+        var publisher = new Mock<IPublisher>();
+        var service = new MediarqGrpcNotificationService(registry, publisher.Object);
+
+        var envelope = new NotificationEnvelope { TypeName = "Some.Unknown.Type", Payload = ByteString.Empty };
+
+        var act = async () => await service.Publish(envelope, TestServerCallContext.Create());
+
+        var exception = await act.Should().ThrowAsync<RpcException>();
+        exception.Which.StatusCode.Should().Be(StatusCode.NotFound);
+    }
+
+    // Minimal ServerCallContext for unit-testing a service method directly, without a real gRPC call.
+    private sealed class TestServerCallContext : ServerCallContext
+    {
+        protected override Task WriteResponseHeadersAsyncCore(Metadata responseHeaders) => Task.CompletedTask;
+        protected override ContextPropagationToken CreatePropagationTokenCore(ContextPropagationOptions? options) => null!;
+        protected override string MethodCore => "Publish";
+        protected override string HostCore => "test";
+        protected override string PeerCore => "test";
+        protected override DateTime DeadlineCore => DateTime.MaxValue;
+        protected override Metadata RequestHeadersCore { get; } = [];
+        protected override CancellationToken CancellationTokenCore { get; } = CancellationToken.None;
+        protected override Metadata ResponseTrailersCore { get; } = [];
+        protected override Status StatusCore { get; set; }
+        protected override WriteOptions? WriteOptionsCore { get; set; }
+        protected override AuthContext AuthContextCore { get; } = new("test", new Dictionary<string, List<AuthProperty>>());
+
+        internal static TestServerCallContext Create() => new();
+    }
+}

--- a/docs/guides/wiring-extensions.md
+++ b/docs/guides/wiring-extensions.md
@@ -372,6 +372,25 @@ without requeue (route to a dead-letter exchange at the broker if you need one) 
 redeliveries — for `Mediarq.MassTransit`'s heavier, batteries-included alternative (retry, outbox,
 saga integration, many transports), see above.
 
+## Mediarq.Grpc — direct point-to-point RPC to another service
+
+```csharp
+// publish (outbound)
+builder.Services.AddMediarqGrpcPublisher<OrderPlaced>();
+
+// subscribe (inbound)
+builder.Services.AddMediarqGrpcSubscriptions();
+// ...
+app.MapMediarqGrpcNotificationService();     // map exactly once
+app.MapMediarqGrpcSubscription<OrderPlaced>();
+```
+Marker: `IGrpcNotificationEvent` (`static abstract string ServiceAddress`). Unlike the broker packages
+above, gRPC is direct point-to-point RPC — the publisher must know the target service's address, there
+is no fan-out or persistence, and a failed `Publish` RPC throws `Grpc.Core.RpcException` like any other
+handler exception. Ships its own compiled Protobuf/gRPC contract, so no `protoc`/`Grpc.Tools` is needed
+downstream. Every subscribed notification type is multiplexed over one shared RPC method; an
+unrecognized `type_name` fails with `StatusCode.NotFound`.
+
 ## Recommended order (a safe template)
 
 ```csharp

--- a/src/Mediarq.Grpc/GrpcChannelCache.cs
+++ b/src/Mediarq.Grpc/GrpcChannelCache.cs
@@ -1,0 +1,35 @@
+using System.Collections.Concurrent;
+using Grpc.Net.Client;
+
+namespace Mediarq.Grpc;
+
+/// <summary>
+/// Caches one long-lived <see cref="GrpcChannel"/> per remote service address, so
+/// <see cref="GrpcNotificationForwarder{TNotification}"/> never opens a new HTTP/2 connection per publish.
+/// Registered as a singleton; disposed by the container at shutdown, which disposes every cached channel.
+/// </summary>
+/// <remarks>
+/// Unlike the Dapr/RabbitMQ/Azure Service Bus packages' "bring your own client" convention, a
+/// <see cref="GrpcChannel"/> is not an external SDK object carrying credentials the app must own — it is
+/// just a pooled HTTP/2 connection to an address already known at compile time via
+/// <see cref="IGrpcNotificationEvent.ServiceAddress"/>, so this package safely owns its lifecycle.
+/// </remarks>
+public sealed class GrpcChannelCache : IDisposable
+{
+    private readonly ConcurrentDictionary<string, GrpcChannel> _channels = new();
+
+    // Public (rather than internal): Microsoft.Extensions.DependencyInjection's default container only
+    // considers public constructors when activating a type, so GrpcNotificationForwarder<TNotification>
+    // (a public class DI must construct) cannot take an internal-typed constructor parameter.
+    internal GrpcChannel GetOrCreate(string address)
+        => _channels.GetOrAdd(address, static a => GrpcChannel.ForAddress(a));
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        foreach (var channel in _channels.Values)
+        {
+            channel.Dispose();
+        }
+    }
+}

--- a/src/Mediarq.Grpc/GrpcEndpointRouteBuilderExtensions.cs
+++ b/src/Mediarq.Grpc/GrpcEndpointRouteBuilderExtensions.cs
@@ -1,0 +1,49 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Mediarq.Grpc;
+
+/// <summary>
+/// Endpoint mapping for the receiving half of gRPC cross-service notifications: the shared
+/// <see cref="MediarqGrpcNotificationService"/>, and the per-notification-type subscription registration.
+/// </summary>
+public static class GrpcEndpointRouteBuilderExtensions
+{
+    /// <summary>
+    /// Maps the single shared gRPC service every subscribed notification type is multiplexed through.
+    /// Requires <see cref="GrpcServiceCollectionExtensions.AddMediarqGrpcSubscriptions"/> to already be
+    /// registered. Map exactly once.
+    /// </summary>
+    /// <param name="app">The endpoint route builder to map the service on.</param>
+    /// <returns>The same route builder, enabling fluent chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="app"/> is <see langword="null"/>.</exception>
+    public static IEndpointRouteBuilder MapMediarqGrpcNotificationService(this IEndpointRouteBuilder app)
+    {
+        ArgumentNullException.ThrowIfNull(app);
+
+        app.MapGrpcService<MediarqGrpcNotificationService>();
+        return app;
+    }
+
+    /// <summary>
+    /// Subscribes to <typeparamref name="TNotification"/>: registers it with the shared
+    /// <see cref="GrpcNotificationSubscriptionRegistry"/> so a gRPC-delivered notification of this type is
+    /// deserialized and republished through the real Mediarq pipeline via
+    /// <see cref="Core.Mediators.IPublisher"/>. Requires
+    /// <see cref="GrpcServiceCollectionExtensions.AddMediarqGrpcSubscriptions"/> to already be registered.
+    /// </summary>
+    /// <typeparam name="TNotification">The notification type to receive.</typeparam>
+    /// <param name="app">The endpoint route builder to register the subscription on.</param>
+    /// <returns>The same route builder, enabling fluent chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="app"/> is <see langword="null"/>.</exception>
+    public static IEndpointRouteBuilder MapMediarqGrpcSubscription<TNotification>(this IEndpointRouteBuilder app)
+        where TNotification : class, IGrpcNotificationEvent
+    {
+        ArgumentNullException.ThrowIfNull(app);
+
+        var registry = app.ServiceProvider.GetRequiredService<GrpcNotificationSubscriptionRegistry>();
+        registry.Add<TNotification>();
+        return app;
+    }
+}

--- a/src/Mediarq.Grpc/GrpcNotificationForwarder.cs
+++ b/src/Mediarq.Grpc/GrpcNotificationForwarder.cs
@@ -1,0 +1,49 @@
+using System.Text.Json;
+using Google.Protobuf;
+using Mediarq.Core.Common.Requests.Notifications;
+using Mediarq.Grpc.Contracts;
+
+namespace Mediarq.Grpc;
+
+/// <summary>
+/// A Mediarq notification handler that forwards the notification, JSON-serialized inside a
+/// <see cref="NotificationEnvelope"/>, to another service's Mediarq gRPC notification endpoint at
+/// <see cref="IGrpcNotificationEvent.ServiceAddress"/>.
+/// </summary>
+/// <typeparam name="TNotification">The notification type to forward.</typeparam>
+/// <remarks>
+/// Registered as a regular <see cref="INotificationHandler{TNotification}"/>, so it runs alongside any
+/// in-process handlers when the notification is published through Mediarq.
+/// </remarks>
+public sealed class GrpcNotificationForwarder<TNotification> : INotificationHandler<TNotification>
+    where TNotification : class, IGrpcNotificationEvent
+{
+    private static readonly string TypeName = typeof(TNotification).FullName!;
+
+    private readonly GrpcChannelCache _channelCache;
+
+    /// <summary>Initializes a new instance of the <see cref="GrpcNotificationForwarder{TNotification}"/> class.</summary>
+    /// <param name="channelCache">The channel cache used to reach <see cref="IGrpcNotificationEvent.ServiceAddress"/>.</param>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="channelCache"/> is <see langword="null"/>.</exception>
+    public GrpcNotificationForwarder(GrpcChannelCache channelCache)
+    {
+        ArgumentNullException.ThrowIfNull(channelCache);
+        _channelCache = channelCache;
+    }
+
+    /// <inheritdoc />
+    public async Task Handle(TNotification notification, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(notification);
+
+        var channel = _channelCache.GetOrCreate(TNotification.ServiceAddress);
+        var client = new NotificationService.NotificationServiceClient(channel);
+        var envelope = new NotificationEnvelope
+        {
+            TypeName = TypeName,
+            Payload = ByteString.CopyFrom(JsonSerializer.SerializeToUtf8Bytes(notification)),
+        };
+
+        await client.PublishAsync(envelope, cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/src/Mediarq.Grpc/GrpcNotificationSubscriptionRegistry.cs
+++ b/src/Mediarq.Grpc/GrpcNotificationSubscriptionRegistry.cs
@@ -1,0 +1,39 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+using Google.Protobuf;
+using Mediarq.Core.Mediators;
+
+namespace Mediarq.Grpc;
+
+/// <summary>
+/// Maps a notification's <see cref="Type.FullName"/> (as carried by a received
+/// <see cref="Contracts.NotificationEnvelope.TypeName"/>) to a compile-time-typed deserialize-and-publish
+/// delegate, so <see cref="MediarqGrpcNotificationService"/> can dispatch every subscribed notification
+/// type through the single shared <c>Publish</c> RPC without any runtime reflection.
+/// </summary>
+/// <remarks>
+/// Populated by <see cref="GrpcEndpointRouteBuilderExtensions.MapMediarqGrpcSubscription{TNotification}"/>
+/// at endpoint-mapping time (mirroring how <c>Mediarq.Dapr</c>'s subscription registry is populated),
+/// rather than at <see cref="Microsoft.Extensions.DependencyInjection.IServiceCollection"/> configuration
+/// time, since only then does the app's <see cref="IServiceProvider"/> exist to resolve this singleton.
+/// </remarks>
+internal sealed class GrpcNotificationSubscriptionRegistry
+{
+    private readonly ConcurrentDictionary<string, Func<ByteString, IPublisher, CancellationToken, Task>> _handlers = new();
+
+    internal void Add<TNotification>()
+        where TNotification : class, IGrpcNotificationEvent
+    {
+        _handlers[typeof(TNotification).FullName!] = static (payload, publisher, cancellationToken) =>
+        {
+            var notification = JsonSerializer.Deserialize<TNotification>(payload.Span)
+                ?? throw new InvalidOperationException(
+                    $"Failed to deserialize a gRPC-delivered '{typeof(TNotification).Name}' notification: the payload deserialized to null.");
+
+            return publisher.Publish(notification, cancellationToken);
+        };
+    }
+
+    internal bool TryGetHandler(string typeName, out Func<ByteString, IPublisher, CancellationToken, Task> handler)
+        => _handlers.TryGetValue(typeName, out handler!);
+}

--- a/src/Mediarq.Grpc/GrpcServiceCollectionExtensions.cs
+++ b/src/Mediarq.Grpc/GrpcServiceCollectionExtensions.cs
@@ -1,0 +1,47 @@
+using Mediarq.Core.Common.Requests.Notifications;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Mediarq.Grpc;
+
+/// <summary>
+/// Extension methods that register the publish and subscribe sides of gRPC cross-service notifications.
+/// </summary>
+public static class GrpcServiceCollectionExtensions
+{
+    /// <summary>
+    /// Forwards a specific notification type to its remote service's Mediarq gRPC notification endpoint
+    /// (<see cref="IGrpcNotificationEvent.ServiceAddress"/>) when it is published through Mediarq.
+    /// </summary>
+    /// <typeparam name="TNotification">The notification type to forward.</typeparam>
+    /// <param name="services">The service collection to configure.</param>
+    /// <returns>The same service collection, enabling fluent chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="services"/> is <see langword="null"/>.</exception>
+    public static IServiceCollection AddMediarqGrpcPublisher<TNotification>(this IServiceCollection services)
+        where TNotification : class, IGrpcNotificationEvent
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.TryAddSingleton<GrpcChannelCache>();
+        services.AddScoped<INotificationHandler<TNotification>, GrpcNotificationForwarder<TNotification>>();
+        return services;
+    }
+
+    /// <summary>
+    /// Registers the gRPC hosting infrastructure and the <see cref="GrpcNotificationSubscriptionRegistry"/>
+    /// that <see cref="GrpcEndpointRouteBuilderExtensions.MapMediarqGrpcNotificationService"/> and
+    /// <see cref="GrpcEndpointRouteBuilderExtensions.MapMediarqGrpcSubscription{TNotification}"/> share.
+    /// Call once before mapping any gRPC subscription.
+    /// </summary>
+    /// <param name="services">The service collection to configure.</param>
+    /// <returns>The same service collection, enabling fluent chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="services"/> is <see langword="null"/>.</exception>
+    public static IServiceCollection AddMediarqGrpcSubscriptions(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddGrpc();
+        services.AddSingleton<GrpcNotificationSubscriptionRegistry>();
+        return services;
+    }
+}

--- a/src/Mediarq.Grpc/IGrpcNotificationEvent.cs
+++ b/src/Mediarq.Grpc/IGrpcNotificationEvent.cs
@@ -1,0 +1,23 @@
+using Mediarq.Core.Common.Requests.Notifications;
+
+namespace Mediarq.Grpc;
+
+/// <summary>
+/// Marks a notification as a gRPC cross-service event — one meant to be forwarded, over gRPC, to another
+/// service's <see cref="GrpcEndpointRouteBuilderExtensions.MapMediarqGrpcNotificationService"/> endpoint
+/// (in addition to any in-process handlers) when published, and/or received back from gRPC into the real
+/// Mediarq pipeline via <see cref="GrpcEndpointRouteBuilderExtensions.MapMediarqGrpcSubscription{TNotification}"/>.
+/// </summary>
+/// <remarks>
+/// <see cref="ServiceAddress"/> is <c>static abstract</c> rather than an instance property (same rationale
+/// as <c>IDaprPubSubEvent</c>/<c>IRabbitMqEvent</c>): the publish side needs this routing information
+/// available before any notification instance exists, and reading it from the type rather than an
+/// instance keeps it impossible for two instances of the same notification type to accidentally target
+/// different remote services.
+/// </remarks>
+public interface IGrpcNotificationEvent : INotification
+{
+    /// <summary>The base address (e.g. <c>https://order-service:5001</c>) of the remote service's Mediarq
+    /// gRPC notification endpoint to forward this notification type to.</summary>
+    static abstract string ServiceAddress { get; }
+}

--- a/src/Mediarq.Grpc/Mediarq.Grpc.csproj
+++ b/src/Mediarq.Grpc/Mediarq.Grpc.csproj
@@ -1,0 +1,53 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <PackageId>Mediarq.Grpc</PackageId>
+    <Version>1.0.0</Version>
+    <Authors>Nicolas Rouffart</Authors>
+    <Description>gRPC transport for cross-service Mediarq notifications: forward a notification to another service's Mediarq.Grpc endpoint when it is published (IGrpcNotificationEvent), and receive it back into the real Mediarq pipeline via a single shared gRPC service. Ships its own compiled Protobuf/gRPC contract — consumers reference this package only, no protoc/Grpc.Tools required.</Description>
+    <PackageTags>mediarq;cqrs;grpc;rpc;dotnet</PackageTags>
+    <PackageProjectUrl>https://github.com/rouffou/mediarq</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/rouffou/mediarq</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Protobuf Include="Protos/notification.proto" GrpcServices="Both" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Google.Protobuf" Version="3.35.1" />
+    <PackageReference Include="Grpc.Net.Client" Version="2.80.0" />
+    <PackageReference Include="Grpc.AspNetCore.Server" Version="2.80.0" />
+    <PackageReference Include="Grpc.Tools" Version="2.83.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Mediarq.Core\Mediarq.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Mediarq.Grpc.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+</Project>

--- a/src/Mediarq.Grpc/MediarqGrpcNotificationService.cs
+++ b/src/Mediarq.Grpc/MediarqGrpcNotificationService.cs
@@ -1,0 +1,28 @@
+using Grpc.Core;
+using Mediarq.Core.Mediators;
+using Mediarq.Grpc.Contracts;
+
+namespace Mediarq.Grpc;
+
+/// <summary>
+/// The single shared gRPC service every subscribed notification type is multiplexed through: looks up
+/// <see cref="NotificationEnvelope.TypeName"/> in the <see cref="GrpcNotificationSubscriptionRegistry"/>,
+/// deserializes the payload, and republishes it through the real Mediarq pipeline via
+/// <see cref="IPublisher"/>. Constructed per call by ASP.NET Core's gRPC hosting, in that call's own DI
+/// scope, so <see cref="IPublisher"/> (Scoped) resolves correctly without any manual scope creation.
+/// </summary>
+internal sealed class MediarqGrpcNotificationService(GrpcNotificationSubscriptionRegistry registry, IPublisher publisher)
+    : NotificationService.NotificationServiceBase
+{
+    /// <inheritdoc />
+    public override async Task<PublishAck> Publish(NotificationEnvelope request, ServerCallContext context)
+    {
+        if (!registry.TryGetHandler(request.TypeName, out var handler))
+        {
+            throw new RpcException(new Status(StatusCode.NotFound, $"No subscriber registered for notification type '{request.TypeName}'."));
+        }
+
+        await handler(request.Payload, publisher, context.CancellationToken).ConfigureAwait(false);
+        return new PublishAck { Accepted = true };
+    }
+}

--- a/src/Mediarq.Grpc/Protos/notification.proto
+++ b/src/Mediarq.Grpc/Protos/notification.proto
@@ -1,0 +1,21 @@
+syntax = "proto3";
+
+option csharp_namespace = "Mediarq.Grpc.Contracts";
+
+package mediarq;
+
+// A single-RPC envelope multiplexing every IGrpcNotificationEvent type over one gRPC service: type_name
+// identifies which notification type payload holds a JSON-serialized instance of, so the receiving side
+// can look up the right deserializer/publish delegate without one RPC method per notification type.
+message NotificationEnvelope {
+  string type_name = 1;
+  bytes payload = 2;
+}
+
+message PublishAck {
+  bool accepted = 1;
+}
+
+service NotificationService {
+  rpc Publish (NotificationEnvelope) returns (PublishAck);
+}

--- a/src/Mediarq.Grpc/PublicAPI.Shipped.txt
+++ b/src/Mediarq.Grpc/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Mediarq.Grpc/PublicAPI.Unshipped.txt
+++ b/src/Mediarq.Grpc/PublicAPI.Unshipped.txt
@@ -1,0 +1,15 @@
+#nullable enable
+Mediarq.Grpc.GrpcChannelCache
+Mediarq.Grpc.GrpcChannelCache.Dispose() -> void
+Mediarq.Grpc.GrpcChannelCache.GrpcChannelCache() -> void
+Mediarq.Grpc.GrpcEndpointRouteBuilderExtensions
+Mediarq.Grpc.GrpcNotificationForwarder<TNotification>
+Mediarq.Grpc.GrpcNotificationForwarder<TNotification>.GrpcNotificationForwarder(Mediarq.Grpc.GrpcChannelCache! channelCache) -> void
+Mediarq.Grpc.GrpcNotificationForwarder<TNotification>.Handle(TNotification! notification, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Mediarq.Grpc.GrpcServiceCollectionExtensions
+Mediarq.Grpc.IGrpcNotificationEvent
+Mediarq.Grpc.IGrpcNotificationEvent.ServiceAddress.get -> string!
+static Mediarq.Grpc.GrpcEndpointRouteBuilderExtensions.MapMediarqGrpcNotificationService(this Microsoft.AspNetCore.Routing.IEndpointRouteBuilder! app) -> Microsoft.AspNetCore.Routing.IEndpointRouteBuilder!
+static Mediarq.Grpc.GrpcEndpointRouteBuilderExtensions.MapMediarqGrpcSubscription<TNotification>(this Microsoft.AspNetCore.Routing.IEndpointRouteBuilder! app) -> Microsoft.AspNetCore.Routing.IEndpointRouteBuilder!
+static Mediarq.Grpc.GrpcServiceCollectionExtensions.AddMediarqGrpcPublisher<TNotification>(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+static Mediarq.Grpc.GrpcServiceCollectionExtensions.AddMediarqGrpcSubscriptions(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!

--- a/src/Mediarq.Grpc/README.md
+++ b/src/Mediarq.Grpc/README.md
@@ -1,0 +1,68 @@
+# Mediarq.Grpc
+
+gRPC transport for cross-service Mediarq notifications: forward a notification to another service's
+Mediarq gRPC endpoint when it is published, and receive it back into the real Mediarq pipeline via a
+single shared gRPC service. Ships its own compiled Protobuf/gRPC contract — reference this package only,
+no `protoc`/`Grpc.Tools` required on your side.
+
+```bash
+dotnet add package Mediarq.Grpc
+```
+
+## Marking an event
+
+```csharp
+public sealed record OrderPlaced(Guid OrderId, string Customer) : IGrpcNotificationEvent
+{
+    public static string ServiceAddress => "https://order-service:5001";
+}
+```
+
+`ServiceAddress` is a `static abstract` member, not an instance property: the publish side needs this
+routing information available before any `OrderPlaced` instance exists, and reading it from the type
+rather than an instance keeps it impossible for two instances of the same notification type to
+accidentally target different remote services.
+
+## Publishing (outbound)
+
+```csharp
+builder.Services.AddMediarqGrpcPublisher<OrderPlaced>();
+```
+
+Now every `IPublisher.Publish(new OrderPlaced(...))` call also calls `OrderPlaced.ServiceAddress`'s
+`NotificationService.Publish` RPC, in addition to running any in-process handlers. The HTTP/2 channel to
+each `ServiceAddress` is cached and reused (not one per publish) and disposed when the app shuts down —
+unlike the Dapr/RabbitMQ/Azure Service Bus packages, this package owns that channel's lifecycle itself,
+since (unlike a Dapr sidecar client, a RabbitMQ connection, or a Service Bus client) it carries no
+external credentials your app needs to configure.
+
+## Subscribing (inbound)
+
+```csharp
+builder.Services.AddMediarqGrpcSubscriptions();
+// ...
+app.MapMediarqGrpcNotificationService();     // map exactly once
+app.MapMediarqGrpcSubscription<OrderPlaced>();
+```
+
+Every subscribed notification type is multiplexed over the single shared gRPC service — there is one RPC
+method (`Publish`), and the envelope's `type_name` field tells the receiving service which registered
+type to deserialize the JSON payload as and republish through `IPublisher`. A gRPC call for a type that
+was never subscribed on this service fails with `StatusCode.NotFound`.
+
+## What this does *not* do
+
+Unlike a message broker (Dapr pub/sub, RabbitMQ, Azure Service Bus), gRPC is direct point-to-point RPC:
+the publisher must know the target service's network address, there is no fan-out, no persistence, and
+no retry/redelivery if the remote service is unreachable — a failed `Publish` RPC throws
+`Grpc.Core.RpcException`, same as any other Mediarq notification handler exception. If you need broker
+semantics (decoupled publisher/subscriber, delivery guarantees, dead-lettering), use one of the other
+transport packages instead.
+
+## Learn more
+
+[Wiring extensions](https://github.com/rouffou/mediarq/blob/main/docs/guides/wiring-extensions.md) ·
+[Full README](https://github.com/rouffou/mediarq#readme) ·
+[gRPC for .NET docs](https://learn.microsoft.com/en-us/aspnet/core/grpc/)
+
+MIT © Nicolas Rouffart


### PR DESCRIPTION
Closes #36 (gRPC half — Quartz.NET/Hangfire scheduled dispatch already shipped via #171).

## What this does

`IGrpcNotificationEvent` (`static abstract string ServiceAddress`) marks a notification for gRPC delivery to another service.

- **Publish**: `AddMediarqGrpcPublisher<TNotification>()` forwards it via `GrpcNotificationForwarder<TNotification>`, which reuses a cached, long-lived HTTP/2 `GrpcChannel` per `ServiceAddress` (`GrpcChannelCache`, disposed by the container at shutdown — this package safely owns that lifecycle, unlike Dapr/RabbitMQ/Azure Service Bus, since a channel carries no external credentials the app must configure).
- **Subscribe**: `AddMediarqGrpcSubscriptions()` + `MapMediarqGrpcNotificationService()` + `MapMediarqGrpcSubscription<TNotification>()` receive it back into the pipeline. Every subscribed type is multiplexed over a single shared RPC method (`Publish`), keyed by the envelope's `type_name` against a registry of compile-time-typed deserialize-and-publish delegates built inside the generic registration call — no runtime reflection on the actual dispatch path.

Ships its own compiled Protobuf/gRPC contract (`Protos/notification.proto`, a `NotificationEnvelope`/`PublishAck` pair, `GrpcServices="Both"`), so consumers reference this package only — no `protoc`/`Grpc.Tools` needed downstream.

## Design notes worth flagging

- I tried generating the contract with `--csharp_opt=internal_access` to avoid exposing it as public API surface. Reverted after confirming it's a known `Grpc.Tools` limitation: the flag only applies to the protobuf message types, not the `grpc_csharp_plugin`-generated service/client stubs, causing an accessibility mismatch (`CS0050`/`CS0051`). The generated surface is public, tracked in `PublicAPI.Unshipped.txt` like every other package.
- `GrpcChannelCache` and `GrpcNotificationForwarder`'s constructor had to be **public**, not internal as I first wrote them: `Microsoft.Extensions.DependencyInjection`'s default container only considers **public** constructors when activating a type, so an internal-typed constructor parameter on a publicly-constructed type silently fails DI resolution. Caught by two failing tests during development, fixed before this PR.
- Unlike a message broker, gRPC is direct point-to-point RPC: the publisher must know the target address, there's no fan-out/persistence, and a failed call throws `Grpc.Core.RpcException` like any other handler exception — documented in the README as a deliberate scope boundary.

## Test plan

- [x] Full solution build: 0 warnings/errors beyond pre-existing, unrelated ones
- [x] Full test suite: 18 new tests (registry, service, DI registration, channel cache, and two real round-trip tests — one via `TestServer`+the real generated client, one via a real bound Kestrel socket exercising the actual forwarder end to end)
- [x] Ad-hoc AOT publish scan of the subscribe side: `AddGrpc()`/`MapGrpcService()` itself produced **zero** trim/AOT warnings. The only warning present is the reflection-based `JsonSerializer.Deserialize<T>` call — the same pre-existing, unannotated pattern already used in the Dapr/RabbitMQ/AzureServiceBus forwarders, not a new risk category introduced here.