### PR TITLE
feat(sourcegen): add MQ005/MQ006/MQ007 diagnostics for stream handlers and notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,8 +126,10 @@ default. Override either via MSBuild:
 
 The generator also emits compile-time diagnostics: `MQ001` (multiple handlers for one request), `MQ002`
 (a command/query with no handler in the assembly), `MQ003` (a validator whose target is neither a
-request nor a notification, so it can never run), and `MQ004` (the reflection-based `AddMediarq(...)`
-called in a project that publishes with Native AOT).
+request nor a notification, so it can never run), `MQ004` (the reflection-based `AddMediarq(...)`
+called in a project that publishes with Native AOT), `MQ005` (multiple `IStreamRequestHandler`s for the
+same stream request), `MQ006` (a stream request with no handler in the assembly), and `MQ007` (a
+notification with no handler in the assembly).
 
 ## Commands & queries (with a result)
 

--- a/Tests/Mediarq.SourceGenerators.Tests/MediarqRegistrationGeneratorTests.cs
+++ b/Tests/Mediarq.SourceGenerators.Tests/MediarqRegistrationGeneratorTests.cs
@@ -164,7 +164,7 @@ public class MediarqRegistrationGeneratorTests
 
         var (generated, diagnostics) = Run(source);
 
-        diagnostics.Should().BeEmpty();
+        diagnostics.Should().ContainSingle(d => d.Id == "MQ007");
         generated.Should().Contain("registry.AddNotification<global::Demo.OrderPlaced>();");
         // No handler exists, so nothing should be registered in the DI container for it.
         generated.Should().NotContain("AddScoped");
@@ -184,7 +184,7 @@ public class MediarqRegistrationGeneratorTests
 
         var (generated, diagnostics) = Run(source);
 
-        diagnostics.Should().BeEmpty();
+        diagnostics.Should().ContainSingle(d => d.Id == "MQ006");
         generated.Should().Contain("registry.AddStream<global::Demo.Ticks, int>();");
         generated.Should().NotContain("AddScoped");
         generated.Should().NotContain("AddSingleton<");
@@ -234,6 +234,125 @@ public class MediarqRegistrationGeneratorTests
         var (_, diagnostics) = Run(source);
 
         diagnostics.Should().Contain(d => d.Id == "MQ002");
+    }
+
+    [Fact]
+    public void Reports_MQ005_For_Multiple_Handlers_Of_Same_Stream_Request()
+    {
+        const string source = """
+            using Mediarq.Core.Common.Requests.Streaming;
+            using System.Collections.Generic;
+            using System.Threading;
+
+            namespace Demo;
+
+            public record Ticks(int N) : IStreamRequest<int>;
+
+            public sealed class TicksHandler1 : IStreamRequestHandler<Ticks, int>
+            {
+                public async IAsyncEnumerable<int> Handle(Ticks request, CancellationToken cancellationToken = default)
+                {
+                    yield return 0;
+                    await System.Threading.Tasks.Task.CompletedTask;
+                }
+            }
+
+            public sealed class TicksHandler2 : IStreamRequestHandler<Ticks, int>
+            {
+                public async IAsyncEnumerable<int> Handle(Ticks request, CancellationToken cancellationToken = default)
+                {
+                    yield return 0;
+                    await System.Threading.Tasks.Task.CompletedTask;
+                }
+            }
+            """;
+
+        var (_, diagnostics) = Run(source);
+
+        diagnostics.Should().Contain(d => d.Id == "MQ005");
+    }
+
+    [Fact]
+    public void Reports_MQ006_For_Stream_Request_Without_Handler()
+    {
+        const string source = """
+            using Mediarq.Core.Common.Requests.Streaming;
+
+            namespace Demo;
+
+            public record Ticks(int N) : IStreamRequest<int>;
+            """;
+
+        var (_, diagnostics) = Run(source);
+
+        diagnostics.Should().Contain(d => d.Id == "MQ006");
+    }
+
+    [Fact]
+    public void Does_Not_Report_MQ006_When_Stream_Request_Has_A_Handler()
+    {
+        const string source = """
+            using Mediarq.Core.Common.Requests.Streaming;
+            using System.Collections.Generic;
+            using System.Threading;
+            using System.Threading.Tasks;
+
+            namespace Demo;
+
+            public record Ticks(int N) : IStreamRequest<int>;
+
+            public sealed class TicksHandler : IStreamRequestHandler<Ticks, int>
+            {
+                public async IAsyncEnumerable<int> Handle(Ticks request, CancellationToken cancellationToken = default)
+                {
+                    for (var i = 0; i < request.N; i++) { yield return i; }
+                    await Task.CompletedTask;
+                }
+            }
+            """;
+
+        var (_, diagnostics) = Run(source);
+
+        diagnostics.Should().NotContain(d => d.Id == "MQ006");
+    }
+
+    [Fact]
+    public void Reports_MQ007_For_Notification_Without_Handler()
+    {
+        const string source = """
+            using Mediarq.Core.Common.Requests.Notifications;
+
+            namespace Demo;
+
+            public record OrderPlaced(int Id) : INotification;
+            """;
+
+        var (_, diagnostics) = Run(source);
+
+        diagnostics.Should().Contain(d => d.Id == "MQ007");
+    }
+
+    [Fact]
+    public void Does_Not_Report_MQ007_When_Notification_Has_A_Handler()
+    {
+        const string source = """
+            using Mediarq.Core.Common.Requests.Notifications;
+            using System.Threading;
+            using System.Threading.Tasks;
+
+            namespace Demo;
+
+            public record OrderPlaced(int Id) : INotification;
+
+            public sealed class AuditHandler : INotificationHandler<OrderPlaced>
+            {
+                public Task Handle(OrderPlaced notification, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            }
+            """;
+
+        var (_, diagnostics) = Run(source);
+
+        diagnostics.Should().NotContain(d => d.Id == "MQ007");
     }
 
     [Fact]

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -25,6 +25,19 @@ generator doesn't see). Add the handler, or ignore if intentional.
 Your `IValidator<T>` is for a `T` that is never dispatched, so it can never run. Point it at a request
 or notification type.
 
+### Build warning `MQ005` — multiple stream handlers for the same stream request
+A stream request must have exactly one `IStreamRequestHandler<,>`. You have two classes implementing
+the handler interface for the same stream request. Delete or merge one.
+
+### Build info `MQ006` — a stream request has no handler in the assembly
+You declared an `IStreamRequest<T>` but never wrote its `IStreamRequestHandler<,>` (or it's in another
+assembly the generator doesn't see). Add the handler, or ignore if intentional.
+
+### Build info `MQ007` — a notification has no handler in the assembly
+You declared an `INotification` but never wrote an `INotificationHandler<>` for it (or it's in another
+assembly, or the notification intentionally has no subscribers yet). Add a handler, or ignore if
+intentional.
+
 ## Lifetime
 
 ### Build warning `MQ200` — Singleton depends on a shorter-lived type

--- a/src/Mediarq.SourceGenerators/MediarqRegistrationGenerator.cs
+++ b/src/Mediarq.SourceGenerators/MediarqRegistrationGenerator.cs
@@ -56,6 +56,30 @@ public sealed class MediarqRegistrationGenerator : IIncrementalGenerator
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true);
 
+    private static readonly DiagnosticDescriptor MultipleStreamHandlers = new(
+        id: "MQ005",
+        title: "Multiple stream handlers for the same stream request",
+        messageFormat: "Multiple handlers are registered for '{0}'. Mediarq dispatches each stream request to a single handler.",
+        category: "Mediarq",
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    private static readonly DiagnosticDescriptor MissingStreamHandler = new(
+        id: "MQ006",
+        title: "No stream handler found for a stream request",
+        messageFormat: "No IStreamRequestHandler was found in this assembly for '{0}'. Define a handler, or ignore this if the handler lives in another assembly.",
+        category: "Mediarq",
+        DiagnosticSeverity.Info,
+        isEnabledByDefault: true);
+
+    private static readonly DiagnosticDescriptor MissingNotificationHandler = new(
+        id: "MQ007",
+        title: "No notification handler found for a notification",
+        messageFormat: "No INotificationHandler was found in this assembly for '{0}'. Define a handler, or ignore this if the handler lives in another assembly or this notification intentionally has no subscribers.",
+        category: "Mediarq",
+        DiagnosticSeverity.Info,
+        isEnabledByDefault: true);
+
     /// <inheritdoc />
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
@@ -464,6 +488,40 @@ public sealed class MediarqRegistrationGenerator : IIncrementalGenerator
         foreach (var orphan in registrations.Where(r => r.Kind == HandlerKind.Validator && r.IsOrphanValidator && r.RequestType != null))
         {
             context.ReportDiagnostic(Diagnostic.Create(OrphanValidator, Location.None, orphan.RequestType));
+        }
+
+        // Diagnose multiple stream handlers registered for the same stream request (a stream request
+        // must be handled by exactly one IStreamRequestHandler, same rule as MQ001).
+        foreach (var group in registrations.Where(r => r.Kind == HandlerKind.StreamHandler).GroupBy(r => r.ServiceType))
+        {
+            if (group.Select(r => r.ImplType).Distinct().Count() > 1)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(MultipleStreamHandlers, Location.None, group.Key));
+            }
+        }
+
+        // Diagnose a declared stream request that has no handler in this assembly (MQ006, informational).
+        var handledStreamRequestTypes = new HashSet<string>(
+            registrations.Where(r => r.Kind == HandlerKind.StreamHandler && r.RequestType != null).Select(r => r.RequestType!));
+
+        foreach (var stream in registrations.Where(r => r.Kind == HandlerKind.StreamDeclaration && r.RequestType != null))
+        {
+            if (!handledStreamRequestTypes.Contains(stream.RequestType!))
+            {
+                context.ReportDiagnostic(Diagnostic.Create(MissingStreamHandler, Location.None, stream.RequestType));
+            }
+        }
+
+        // Diagnose a declared notification that has no handler in this assembly (MQ007, informational).
+        var handledNotificationTypes = new HashSet<string>(
+            registrations.Where(r => r.Kind == HandlerKind.NotificationHandler && r.NotificationType != null).Select(r => r.NotificationType!));
+
+        foreach (var notification in registrations.Where(r => r.Kind == HandlerKind.NotificationDeclaration && r.NotificationType != null))
+        {
+            if (!handledNotificationTypes.Contains(notification.NotificationType!))
+            {
+                context.ReportDiagnostic(Diagnostic.Create(MissingNotificationHandler, Location.None, notification.NotificationType));
+            }
         }
 
         var sb = new StringBuilder();


### PR DESCRIPTION
## Summary
- The generator already diagnosed duplicate/missing `IRequestHandler<,>` registrations (MQ001/MQ002) for commands and queries, but never applied the same checks to `IStreamRequestHandler<,>` or `INotificationHandler<>` — a missing or duplicate stream handler, or an orphan notification, only surfaced as a runtime `HandlerNotFoundException`.
- Adds `MQ005` (warning): multiple `IStreamRequestHandler<,>` registered for the same stream request.
- Adds `MQ006` (info): a declared `IStreamRequest<T>` with no handler in the compiling assembly.
- Adds `MQ007` (info): a declared `INotification` with no handler in the compiling assembly.
- No new infrastructure: reuses the registration data the generator already collects for wrapper-registry emission, mirroring the existing MQ001/MQ002 loops in `Emit`.

## Test plan
- [x] `dotnet test Tests/Mediarq.SourceGenerators.Tests` — 24/24 passing, including new MQ005/MQ006/MQ007 coverage and updated existing tests that previously asserted an empty diagnostics list for unhandled stream/notification declarations.
- [x] `dotnet build Mediarq.sln -c Release` — 0 errors, no new diagnostics surfaced elsewhere in the solution (only pre-existing protoc-generated RS0016/RS0041 warnings in Mediarq.Grpc).
- [x] `dotnet test Mediarq.sln -c Release --no-build` — full suite green.

Closes #213.