### PR TITLE
feat(analyzers): add MQ202 to flag duplicate Mediarq routes at compile time

### DIFF
--- a/Tests/Mediarq.Analyzers.Tests/DuplicateRouteAnalyzerTests.cs
+++ b/Tests/Mediarq.Analyzers.Tests/DuplicateRouteAnalyzerTests.cs
@@ -1,0 +1,152 @@
+using Mediarq.Analyzers;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+
+namespace Mediarq.Analyzers.Tests;
+
+public class DuplicateRouteAnalyzerTests
+{
+    // Minimal stubs for the attributes the analyzer looks for by name/namespace.
+    private const string Stubs = @"
+namespace Mediarq.AspNetCore
+{
+    [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Struct, Inherited = false)]
+    public sealed class MediarqGetAttribute : System.Attribute
+    {
+        public MediarqGetAttribute(string pattern) => Pattern = pattern;
+        public string Pattern { get; }
+    }
+
+    [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Struct, Inherited = false)]
+    public sealed class MediarqPostAttribute : System.Attribute
+    {
+        public MediarqPostAttribute(string pattern) => Pattern = pattern;
+        public string Pattern { get; }
+    }
+
+    [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Struct, Inherited = false)]
+    public sealed class MediarqPutAttribute : System.Attribute
+    {
+        public MediarqPutAttribute(string pattern) => Pattern = pattern;
+        public string Pattern { get; }
+    }
+
+    [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Struct, Inherited = false)]
+    public sealed class MediarqPatchAttribute : System.Attribute
+    {
+        public MediarqPatchAttribute(string pattern) => Pattern = pattern;
+        public string Pattern { get; }
+    }
+
+    [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Struct, Inherited = false)]
+    public sealed class MediarqDeleteAttribute : System.Attribute
+    {
+        public MediarqDeleteAttribute(string pattern) => Pattern = pattern;
+        public string Pattern { get; }
+    }
+}
+";
+
+    private static async Task VerifyAsync(string source, params DiagnosticResult[] expected)
+    {
+        var test = new CSharpAnalyzerTest<DuplicateRouteAnalyzer, DefaultVerifier>
+        {
+            TestCode = source + Stubs,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+            CompilerDiagnostics = CompilerDiagnostics.None,
+        };
+        test.ExpectedDiagnostics.AddRange(expected);
+        await test.RunAsync();
+    }
+
+    private static DiagnosticResult Diagnostic(int markupKey)
+        => new DiagnosticResult(DuplicateRouteAnalyzer.DiagnosticId, DiagnosticSeverity.Warning).WithLocation(markupKey);
+
+    // Diagnostics are reported deterministically ordered by fully-qualified type name; the first name
+    // in that order is treated as the "canonical" declaration and every later one is flagged against it.
+    [Fact]
+    public async Task Flags_Two_Types_Declaring_The_Same_Method_And_Pattern()
+    {
+        const string source = @"
+using Mediarq.AspNetCore;
+
+[{|#0:MediarqGet(""/orders/{id}"")|}]
+public class GetOrder { }
+
+[MediarqGet(""/orders/{id}"")]
+public class FetchOrder { }
+";
+        await VerifyAsync(source, Diagnostic(0).WithArguments("GetOrder", "FetchOrder", "GET", "/orders/{id}"));
+    }
+
+    [Fact]
+    public async Task Flags_Every_Type_After_The_First_When_Three_Types_Collide()
+    {
+        const string source = @"
+using Mediarq.AspNetCore;
+
+[{|#0:MediarqGet(""/orders/{id}"")|}]
+public class GetOrder { }
+
+[MediarqGet(""/orders/{id}"")]
+public class FetchOrder { }
+
+[{|#1:MediarqGet(""/orders/{id}"")|}]
+public class LoadOrder { }
+";
+        await VerifyAsync(
+            source,
+            Diagnostic(0).WithArguments("GetOrder", "FetchOrder", "GET", "/orders/{id}"),
+            Diagnostic(1).WithArguments("LoadOrder", "FetchOrder", "GET", "/orders/{id}"));
+    }
+
+    [Fact]
+    public Task Does_Not_Flag_Same_Pattern_With_Different_Methods()
+        => VerifyAsync(@"
+using Mediarq.AspNetCore;
+
+[MediarqGet(""/orders/{id}"")]
+public class GetOrder { }
+
+[MediarqDelete(""/orders/{id}"")]
+public class DeleteOrder { }
+");
+
+    [Fact]
+    public Task Does_Not_Flag_Different_Patterns_With_The_Same_Method()
+        => VerifyAsync(@"
+using Mediarq.AspNetCore;
+
+[MediarqGet(""/orders/{id}"")]
+public class GetOrder { }
+
+[MediarqGet(""/orders/{id}/items"")]
+public class GetOrderItems { }
+");
+
+    [Fact]
+    public Task Does_Not_Flag_A_Single_Type_Declaring_A_Route()
+        => VerifyAsync(@"
+using Mediarq.AspNetCore;
+
+[MediarqPost(""/orders"")]
+public class CreateOrder { }
+");
+
+    [Fact]
+    public Task Does_Not_Flag_An_Unrelated_Attribute_With_The_Same_Name()
+        => VerifyAsync(@"
+[MediarqGet(""/orders/{id}"")]
+public class GetOrder { }
+
+[MediarqGet(""/orders/{id}"")]
+public class FetchOrder { }
+
+[System.AttributeUsage(System.AttributeTargets.Class)]
+public sealed class MediarqGetAttribute : System.Attribute
+{
+    public MediarqGetAttribute(string pattern) { }
+}
+");
+}

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -84,6 +84,20 @@ This is a syntactic check, not a proof over every possible request type: it only
 is literally the `false` literal (an expression-bodied property, an expression-bodied getter, or a single
 `return false;`) — real conditional logic, however it evaluates at runtime, is never flagged.
 
+## Routing
+
+### Build warning `MQ202` — duplicate Mediarq route
+Two request types carry a Mediarq route attribute (`[MediarqGet]`/`[MediarqPost]`/`[MediarqPut]`/
+`[MediarqPatch]`/`[MediarqDelete]`) with the same HTTP method and route pattern. `MapMediarq()` maps
+both with no uniqueness check, so without this analyzer the collision would only surface as ASP.NET
+Core's ambiguous-match error, at the first request that matches the pattern.
+
+Fix by giving one of the two a distinct pattern, or removing the redundant type.
+
+This is an exact, literal match of the method and the pattern text — it does not parse route pattern
+syntax, so two patterns that are equivalent but written differently (e.g. differing only by a route
+constraint) are not detected.
+
 ## Validation
 
 ### My validation never runs (no error, the handler just runs)

--- a/src/Mediarq.Analyzers/DuplicateRouteAnalyzer.cs
+++ b/src/Mediarq.Analyzers/DuplicateRouteAnalyzer.cs
@@ -1,0 +1,144 @@
+using System.Collections.Concurrent;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Mediarq.Analyzers;
+
+/// <summary>
+/// Reports two Mediarq-attributed request types (<c>[MediarqGet]</c>/<c>[MediarqPost]</c>/<c>[MediarqPut]</c>/
+/// <c>[MediarqPatch]</c>/<c>[MediarqDelete]</c>) declaring the same <c>(HTTP method, route pattern)</c> pair.
+/// <c>Mediarq.AspNetCore.MediarqEndpointRouteBuilderExtensions.MapMediarq</c> maps every attributed type
+/// with zero uniqueness check, so two colliding types only surface as an ambiguous-match error at
+/// ASP.NET Core's routing time, on the first request that matches the shared pattern — never at build time.
+/// </summary>
+/// <remarks>
+/// This is a syntactic/string check over the attribute's literal pattern argument, mirroring
+/// <see cref="CaptiveDependencyAnalyzer"/>'s by-name/by-namespace matching: it does not parse route
+/// pattern syntax (parameter names, constraints, ...), so patterns that are equivalent but written
+/// differently (e.g. differing only by a route constraint) are not detected. It only flags an exact,
+/// literal match of both the HTTP method and the pattern text.
+/// </remarks>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class DuplicateRouteAnalyzer : DiagnosticAnalyzer
+{
+    /// <summary>The diagnostic id reported for a duplicate Mediarq route.</summary>
+    public const string DiagnosticId = "MQ202";
+
+    private const string RouteAttributesNamespace = "Mediarq.AspNetCore";
+
+    private static readonly (string AttributeName, string Method)[] RouteAttributes =
+    [
+        ("MediarqGetAttribute", "GET"),
+        ("MediarqPostAttribute", "POST"),
+        ("MediarqPutAttribute", "PUT"),
+        ("MediarqPatchAttribute", "PATCH"),
+        ("MediarqDeleteAttribute", "DELETE"),
+    ];
+
+    private static readonly DiagnosticDescriptor Rule = new(
+        id: DiagnosticId,
+        title: "Duplicate Mediarq route",
+        messageFormat: "'{0}' declares the same route as '{1}' ({2} {3}) -- ASP.NET Core will not be able to disambiguate them at request time",
+        category: "Mediarq.Routing",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "Two Mediarq-attributed request types declare the same (HTTP method, route pattern) pair. MapMediarq() maps both with no uniqueness check, so the collision only surfaces as ASP.NET Core's ambiguous-match error on the first request that matches the pattern, never at build time.",
+        helpLinkUri: "https://github.com/rouffou/mediarq/blob/main/docs/guides/troubleshooting.md",
+        customTags: WellKnownDiagnosticTags.CompilationEnd);
+
+    /// <inheritdoc />
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+    /// <inheritdoc />
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterCompilationStartAction(startContext =>
+        {
+            var routes = new ConcurrentBag<RouteDeclaration>();
+            startContext.RegisterSymbolAction(symbolContext => CollectRoutes(symbolContext, routes), SymbolKind.NamedType);
+            startContext.RegisterCompilationEndAction(endContext => ReportDuplicates(endContext, routes));
+        });
+    }
+
+    private static void CollectRoutes(SymbolAnalysisContext context, ConcurrentBag<RouteDeclaration> routes)
+    {
+        var type = (INamedTypeSymbol)context.Symbol;
+        if (type.TypeKind is not (TypeKind.Class or TypeKind.Struct))
+        {
+            return;
+        }
+
+        foreach (var attribute in type.GetAttributes())
+        {
+            var attributeClass = attribute.AttributeClass;
+            if (attributeClass is null || attributeClass.ContainingNamespace?.ToDisplayString() != RouteAttributesNamespace)
+            {
+                continue;
+            }
+
+            var method = RouteAttributes.FirstOrDefault(r => r.AttributeName == attributeClass.Name).Method;
+            if (method is null)
+            {
+                continue;
+            }
+
+            if (attribute.ConstructorArguments.Length == 0 || attribute.ConstructorArguments[0].Value is not string pattern)
+            {
+                continue;
+            }
+
+            var location = attribute.ApplicationSyntaxReference?.GetSyntax(context.CancellationToken).GetLocation()
+                ?? type.Locations.FirstOrDefault()
+                ?? Location.None;
+
+            routes.Add(new RouteDeclaration(type, method, pattern, location));
+        }
+    }
+
+    private static void ReportDuplicates(CompilationAnalysisContext context, ConcurrentBag<RouteDeclaration> routes)
+    {
+        foreach (var group in routes.GroupBy(r => (r.Method, r.Pattern)))
+        {
+            var ordered = group
+                .OrderBy(r => r.Type.ToDisplayString(), System.StringComparer.Ordinal)
+                .ToList();
+
+            if (ordered.Select(r => r.Type).Distinct(SymbolEqualityComparer.Default).Count() < 2)
+            {
+                continue;
+            }
+
+            var first = ordered[0];
+            foreach (var duplicate in ordered.Skip(1))
+            {
+                if (SymbolEqualityComparer.Default.Equals(duplicate.Type, first.Type))
+                {
+                    continue;
+                }
+
+                context.ReportDiagnostic(Diagnostic.Create(
+                    Rule, duplicate.Location, duplicate.Type.Name, first.Type.Name, duplicate.Method, duplicate.Pattern));
+            }
+        }
+    }
+
+    private sealed class RouteDeclaration
+    {
+        public RouteDeclaration(INamedTypeSymbol type, string method, string pattern, Location location)
+        {
+            Type = type;
+            Method = method;
+            Pattern = pattern;
+            Location = location;
+        }
+
+        public INamedTypeSymbol Type { get; }
+        public string Method { get; }
+        public string Pattern { get; }
+        public Location Location { get; }
+    }
+}

--- a/src/Mediarq.Analyzers/PublicAPI.Unshipped.txt
+++ b/src/Mediarq.Analyzers/PublicAPI.Unshipped.txt
@@ -1,15 +1,20 @@
 #nullable enable
 const Mediarq.Analyzers.CaptiveDependencyAnalyzer.DiagnosticId = "MQ200" -> string!
+const Mediarq.Analyzers.DuplicateRouteAnalyzer.DiagnosticId = "MQ202" -> string!
 const Mediarq.Analyzers.InertConditionalBehaviorAnalyzer.DiagnosticId = "MQ204" -> string!
 const Mediarq.Analyzers.PipelineBehaviorNextAnalyzer.DiagnosticId = "MQ201" -> string!
 Mediarq.Analyzers.CaptiveDependencyAnalyzer
 Mediarq.Analyzers.CaptiveDependencyAnalyzer.CaptiveDependencyAnalyzer() -> void
+Mediarq.Analyzers.DuplicateRouteAnalyzer
+Mediarq.Analyzers.DuplicateRouteAnalyzer.DuplicateRouteAnalyzer() -> void
 Mediarq.Analyzers.InertConditionalBehaviorAnalyzer
 Mediarq.Analyzers.InertConditionalBehaviorAnalyzer.InertConditionalBehaviorAnalyzer() -> void
 Mediarq.Analyzers.PipelineBehaviorNextAnalyzer
 Mediarq.Analyzers.PipelineBehaviorNextAnalyzer.PipelineBehaviorNextAnalyzer() -> void
 override Mediarq.Analyzers.CaptiveDependencyAnalyzer.Initialize(Microsoft.CodeAnalysis.Diagnostics.AnalysisContext! context) -> void
 override Mediarq.Analyzers.CaptiveDependencyAnalyzer.SupportedDiagnostics.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.DiagnosticDescriptor!>
+override Mediarq.Analyzers.DuplicateRouteAnalyzer.Initialize(Microsoft.CodeAnalysis.Diagnostics.AnalysisContext! context) -> void
+override Mediarq.Analyzers.DuplicateRouteAnalyzer.SupportedDiagnostics.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.DiagnosticDescriptor!>
 override Mediarq.Analyzers.InertConditionalBehaviorAnalyzer.Initialize(Microsoft.CodeAnalysis.Diagnostics.AnalysisContext! context) -> void
 override Mediarq.Analyzers.InertConditionalBehaviorAnalyzer.SupportedDiagnostics.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.DiagnosticDescriptor!>
 override Mediarq.Analyzers.PipelineBehaviorNextAnalyzer.Initialize(Microsoft.CodeAnalysis.Diagnostics.AnalysisContext! context) -> void


### PR DESCRIPTION
## Summary
- `MapMediarq()` (`Mediarq.AspNetCore`) maps every `[MediarqGet]`/`[MediarqPost]`/`[MediarqPut]`/`[MediarqPatch]`/`[MediarqDelete]`-attributed request type to a minimal-API endpoint with zero uniqueness check across types. Two request types declaring the same `(HttpMethod, RoutePattern)` pair only collided at ASP.NET Core's routing time (an ambiguous-match error on the first matching request), never at build time.
- Adds `DuplicateRouteAnalyzer` (`MQ202`, warning): collects every Mediarq route attribute declared in the compilation and flags a `(Method, Pattern)` pair declared by more than one type.
- Same shape as the existing `MQ200`/`MQ201`/`MQ204` analyzers: string/attribute-pattern matching by name and namespace over discovered types, no new infrastructure, no changes to `Mediarq.Core` or `Mediarq.AspNetCore` runtime behavior.
- Documented in `docs/guides/troubleshooting.md` under a new "Routing" section.

## Test plan
- [x] `dotnet test Tests/Mediarq.Analyzers.Tests` — 45/45 passing, including 6 new tests covering: two/three colliding types, same pattern with different methods (not flagged), different patterns with the same method (not flagged), a single declaring type (not flagged), and an unrelated same-named attribute in a different namespace (not flagged).
- [x] `dotnet build Mediarq.sln -c Release` — 0 errors, 0 warnings.
- [x] `dotnet test Mediarq.sln -c Release --no-build` — full suite green.

Closes #214.