### PR TITLE
feat(aspnetcore): declare OpenAPI response metadata for MapMediarq() endpoints

### DIFF
--- a/Tests/Mediarq.AspNetCore.Tests/Fixtures/MinimalApiFixtures.cs
+++ b/Tests/Mediarq.AspNetCore.Tests/Fixtures/MinimalApiFixtures.cs
@@ -30,6 +30,23 @@ public sealed class CreateOrderHandler : ICommandHandler<CreateOrder, Result<Gui
     }
 }
 
+[MediarqPut("/orders/{id}/customer")]
+public sealed record RenameOrder(Guid Id, string Customer) : ICommand<Result>;
+
+public sealed class RenameOrderHandler : ICommandHandler<RenameOrder, Result>
+{
+    public Task<Result> Handle(RenameOrder request, CancellationToken cancellationToken = default)
+    {
+        if (!Store.Orders.TryGetValue(request.Id, out var existing))
+        {
+            return Task.FromResult(Result.Failure(ResultError.NotFound("Order.NotFound", "Order not found.")));
+        }
+
+        Store.Orders[request.Id] = existing with { Customer = request.Customer };
+        return Task.FromResult(Result.Success());
+    }
+}
+
 [MediarqDelete("/orders/{id}")]
 public sealed record DeleteOrder(Guid Id) : ICommand;
 

--- a/Tests/Mediarq.AspNetCore.Tests/MediarqEndpointRouteBuilderExtensionsOpenApiTests.cs
+++ b/Tests/Mediarq.AspNetCore.Tests/MediarqEndpointRouteBuilderExtensionsOpenApiTests.cs
@@ -1,0 +1,83 @@
+using FluentAssertions;
+using Mediarq.AspNetCore.Tests.Fixtures;
+using Mediarq.Extensions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Metadata;
+using Microsoft.AspNetCore.Routing;
+
+namespace Mediarq.AspNetCore.Tests;
+
+public class MediarqEndpointRouteBuilderExtensionsOpenApiTests
+{
+    private static WebApplication CreateMappedApp()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.Services.AddMediarq(isHttp: false, typeof(MediarqEndpointRouteBuilderExtensionsOpenApiTests).Assembly);
+
+        var app = builder.Build();
+        app.MapMediarq(typeof(MediarqEndpointRouteBuilderExtensionsOpenApiTests).Assembly);
+        return app;
+    }
+
+    private static RouteEndpoint FindEndpoint(WebApplication app, string method, string pattern) =>
+        ((IEndpointRouteBuilder)app).DataSources
+            .SelectMany(ds => ds.Endpoints)
+            .OfType<RouteEndpoint>()
+            .Single(e =>
+                e.RoutePattern.RawText == pattern &&
+                e.Metadata.GetMetadata<IHttpMethodMetadata>()!.HttpMethods.Contains(method));
+
+    private static IReadOnlyList<IProducesResponseTypeMetadata> ResponseMetadata(RouteEndpoint endpoint) =>
+        endpoint.Metadata.GetOrderedMetadata<IProducesResponseTypeMetadata>();
+
+    private static readonly int[] FailureStatusCodes =
+    [
+        StatusCodes.Status400BadRequest,
+        StatusCodes.Status401Unauthorized,
+        StatusCodes.Status403Forbidden,
+        StatusCodes.Status404NotFound,
+        StatusCodes.Status409Conflict,
+        StatusCodes.Status500InternalServerError,
+    ];
+
+    [Fact]
+    public void Query_Returning_ResultOfT_Declares_200_With_The_Value_Type_And_Failure_Statuses()
+    {
+        using var app = CreateMappedApp();
+        var metadata = ResponseMetadata(FindEndpoint(app, "GET", "/orders/{id}"));
+
+        metadata.Should().ContainSingle(m => m.StatusCode == StatusCodes.Status200OK && m.Type == typeof(OrderDto));
+        metadata.Select(m => m.StatusCode).Should().Contain(FailureStatusCodes);
+    }
+
+    [Fact]
+    public void Command_Returning_ResultOfT_Declares_200_With_The_Value_Type_And_Failure_Statuses()
+    {
+        using var app = CreateMappedApp();
+        var metadata = ResponseMetadata(FindEndpoint(app, "POST", "/orders"));
+
+        metadata.Should().ContainSingle(m => m.StatusCode == StatusCodes.Status200OK && m.Type == typeof(Guid));
+        metadata.Select(m => m.StatusCode).Should().Contain(FailureStatusCodes);
+    }
+
+    [Fact]
+    public void Command_Returning_Result_Declares_204_And_Failure_Statuses()
+    {
+        using var app = CreateMappedApp();
+        var metadata = ResponseMetadata(FindEndpoint(app, "PUT", "/orders/{id}/customer"));
+
+        metadata.Should().ContainSingle(m => m.StatusCode == StatusCodes.Status204NoContent);
+        metadata.Select(m => m.StatusCode).Should().Contain(FailureStatusCodes);
+    }
+
+    [Fact]
+    public void No_Result_Command_Declares_Only_204()
+    {
+        using var app = CreateMappedApp();
+        var metadata = ResponseMetadata(FindEndpoint(app, "DELETE", "/orders/{id}"));
+
+        metadata.Should().ContainSingle();
+        metadata.Single().StatusCode.Should().Be(StatusCodes.Status204NoContent);
+    }
+}

--- a/docs/guides/wiring-extensions.md
+++ b/docs/guides/wiring-extensions.md
@@ -72,6 +72,11 @@ app.MapMediarq(typeof(GetOrder).Assembly);
 `[MediarqGet]`/`[MediarqDelete]` bind members individually from the route/query string (`[AsParameters]`,
 no body); `[MediarqPost]`/`[MediarqPut]`/`[MediarqPatch]` bind the whole request from the JSON body.
 
+Every mapped endpoint also declares its response shapes for ASP.NET Core's OpenAPI generator
+(`Microsoft.AspNetCore.OpenApi`/Swagger): `200`/`204` with the success type (or no body), plus
+`400`/`401`/`403`/`404`/`409`/`500` — the full set `ResultError.Type` can map to — so generated
+Swagger/OpenAPI documents show a typed response instead of a bare, untyped `IResult`.
+
 ## Mediarq.Caching — memoize a query
 
 ```csharp

--- a/src/Mediarq.AspNetCore/MediarqEndpointRouteBuilderExtensions.cs
+++ b/src/Mediarq.AspNetCore/MediarqEndpointRouteBuilderExtensions.cs
@@ -140,7 +140,7 @@ public static class MediarqEndpointRouteBuilderExtensions
                 $"'{requestType}' has a Mediarq route attribute but its response type '{responseType}' is not Result, Result<T> or Unit (a no-result ICommand).");
         }
 
-        _ = method switch
+        var routeBuilder = method switch
         {
             "GET" => group.MapGet(pattern, handler),
             "POST" => group.MapPost(pattern, handler),
@@ -149,6 +149,38 @@ public static class MediarqEndpointRouteBuilderExtensions
             "DELETE" => group.MapDelete(pattern, handler),
             _ => throw new InvalidOperationException($"Unsupported HTTP method '{method}'."),
         };
+
+        WithOpenApiMetadata(routeBuilder, responseType);
+    }
+
+    // Declares the response shapes ASP.NET Core's OpenAPI generator can't infer on its own from the
+    // handler delegate's bare IResult return type: a success shape driven by the response type, plus
+    // every failure shape ToHttpResult()/ToProblem() can actually produce (see ResultHttpExtensions.ToStatusCode).
+    private static void WithOpenApiMetadata(RouteHandlerBuilder builder, Type responseType)
+    {
+        if (responseType == typeof(Unit))
+        {
+            builder.Produces(StatusCodes.Status204NoContent);
+            return;
+        }
+
+        if (responseType == typeof(Result))
+        {
+            builder.Produces(StatusCodes.Status204NoContent);
+        }
+        else
+        {
+            var valueType = responseType.GetGenericArguments()[0];
+            builder.Produces(StatusCodes.Status200OK, valueType);
+        }
+
+        builder
+            .ProducesValidationProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status403Forbidden)
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status409Conflict)
+            .ProducesProblem(StatusCodes.Status500InternalServerError);
     }
 
     private static Type HandlerDelegateType(Type requestType) =>


### PR DESCRIPTION
## Summary
- `MapMediarq()` built its minimal-API delegates as `Func<TRequest, ISender, CancellationToken, Task<IResult>>` and returned a bare `IResult` from its `Handle*` helpers. ASP.NET Core's built-in OpenAPI inference (`Microsoft.AspNetCore.OpenApi`) needs a statically-typed `Results<...>` union or explicit `.Produces<T>()` calls to infer a response schema — neither was present, so every `MapMediarq()`-mapped endpoint showed up in Swagger with an untyped or absent response body.
- Attaches explicit response metadata to the `RouteHandlerBuilder` returned by each `MapGet`/`MapPost`/`MapPut`/`MapPatch`/`MapDelete` call: `200`/`204` with the success type (driven by the response shape — `Result`, `Result<T>` or `Unit`), plus every failure status `ResultError.Type` can map to (`400`/`401`/`403`/`404`/`409`/`500`), reusing the existing `ErrorType` → HTTP status mapping in `ResultHttpExtensions.ToStatusCode`.
- Self-contained to `Mediarq.AspNetCore`; no changes to `Mediarq.Core` or runtime dispatch behavior.
- Documented in `docs/guides/wiring-extensions.md`.

## Test plan
- [x] `dotnet test Tests/Mediarq.AspNetCore.Tests` — 29/29 passing, including 4 new tests asserting `IProducesResponseTypeMetadata` on the mapped endpoints for each response shape (`Result<T>` via query params, `Result<T>` via body, `Result` via body, and a no-result `Unit` command).
- [x] `dotnet build Mediarq.sln -c Release` — 0 errors, 0 warnings, builds clean across net8.0/net9.0/net10.0.
- [x] `dotnet test Mediarq.sln -c Release --no-build` — full suite green.

Closes #215.