### PR TITLE
feat(core): let a handler cascade follow-up notifications via Result.WithNotifications(...)

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,24 @@ whole batch. This is opt-in and per-notification-type: publishing a type that do
 reflection (walking the base-type hierarchy with `MakeGenericType`), so it's not part of the trimming/AOT
 fast path.
 
+### Cascaded notifications — `Result.WithNotifications(...)` (opt-in)
+
+A handler can attach follow-up notifications to its own result instead of injecting `IPublisher` and
+calling `Publish(...)` itself — what the handler causes to happen next shows up in its return value:
+
+```csharp
+public Task<Result<Guid>> Handle(CreateOrder request, CancellationToken cancellationToken = default)
+{
+    var id = Guid.NewGuid();
+    // ... persist the order ...
+    return Task.FromResult(Result.Success(id).WithNotifications(new OrderPlaced(id)));
+}
+```
+The mediator publishes attached notifications automatically once the request finishes dispatching —
+after every behavior/exception handler/post-processor has run, and **only when the result is a
+success** — through the same `IPublisher`/`INotificationPublisher` as an explicit `Publish(...)` call.
+See [Wiring extensions](docs/guides/wiring-extensions.md#cascaded-notifications--resultwithnotifications).
+
 ### Out-of-process notifications (MassTransit)
 
 The optional **`Mediarq.MassTransit`** package forwards notifications to a MassTransit bus, so other

--- a/Tests/Mediarq.Tests/Core/Common/Results/ResultTests.cs
+++ b/Tests/Mediarq.Tests/Core/Common/Results/ResultTests.cs
@@ -1,10 +1,13 @@
 ﻿using FluentAssertions;
+using Mediarq.Core.Common.Requests.Notifications;
 using Mediarq.Core.Common.Results;
 
 namespace Mediarq.Tests.Core.Common.Results;
 
 public class ResultTests
 {
+    private sealed record SampleNotification(string Text) : INotification;
+
     private static readonly ResultError SampleFailure = ResultError.Failure("SampleError", "This is a sample error message.");
 
     [Fact]
@@ -103,5 +106,67 @@ public class ResultTests
         Action act = () => { var value = result.Value; };
         // Assert
         act.Should().Throw<InvalidOperationException>().WithMessage("The value of a failure result can't be accessed");
+    }
+
+    [Fact]
+    public void CascadedNotifications_IsEmpty_ByDefault()
+    {
+        var result = Result.Success();
+
+        result.CascadedNotifications.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void WithNotifications_OnResult_AttachesNotifications_AndReturnsSameInstance()
+    {
+        var result = Result.Success();
+        var notification = new SampleNotification("first");
+
+        var returned = result.WithNotifications(notification);
+
+        returned.Should().BeSameAs(result);
+        result.CascadedNotifications.Should().ContainSingle().Which.Should().Be(notification);
+    }
+
+    [Fact]
+    public void WithNotifications_OnResultOfT_ReturnsResultOfT_ForFluentChaining()
+    {
+        // Compiles only if WithNotifications on Result<T> returns Result<T>, not the base Result.
+        Result<int> result = Result.Success(42).WithNotifications(new SampleNotification("cascade"));
+
+        result.Value.Should().Be(42);
+        result.CascadedNotifications.Should().ContainSingle().Which.Should().BeOfType<SampleNotification>();
+    }
+
+    [Fact]
+    public void WithNotifications_CalledMultipleTimes_AccumulatesNotifications()
+    {
+        var result = Result.Success();
+
+        result.WithNotifications(new SampleNotification("a"));
+        result.WithNotifications(new SampleNotification("b"), new SampleNotification("c"));
+
+        result.CascadedNotifications.Should().HaveCount(3);
+        result.CascadedNotifications.Select(n => ((SampleNotification)n).Text).Should().Equal("a", "b", "c");
+    }
+
+    [Fact]
+    public void WithNotifications_WithNoArguments_DoesNothing()
+    {
+        var result = Result.Success();
+
+        result.WithNotifications();
+
+        result.CascadedNotifications.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void WithNotifications_NullArgument_ShouldThrowArgumentNullException()
+    {
+        var result = Result.Success();
+
+        Action act = () => result.WithNotifications(null!);
+
+        act.Should().Throw<ArgumentNullException>();
     }
 }

--- a/Tests/Mediarq.Tests/Core/Mediators/MediatorTests.cs
+++ b/Tests/Mediarq.Tests/Core/Mediators/MediatorTests.cs
@@ -239,6 +239,55 @@ public class MediatorTests
     }
 
     [Fact]
+    public async Task Send_Should_Publish_CascadedNotifications_When_The_Handler_Completes_Asynchronously()
+    {
+        // Task.Yield() forces the handler's task to be genuinely incomplete when Handle(...) returns
+        // synchronously — exercising the await-path (as opposed to the IsCompletedSuccessfully fast path
+        // the other tests hit, since Moq's ReturnsAsync/.Returns(Result) always yields an already-completed task).
+        var request = new TestCommand("Hello");
+        var notification = new TestNotification("async-cascade");
+
+        _mockHandler
+            .Setup(h => h.Handle(request, It.IsAny<CancellationToken>()))
+            .Returns(async () =>
+            {
+                await Task.Yield();
+                return Result.Success("OK").WithNotifications(notification);
+            });
+
+        var mockPublisher = new Mock<IPublisher>();
+        mockPublisher.Setup(p => p.Publish(It.IsAny<INotification>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        _mockHandlerResolver.Setup(r => r.Resolve<IPublisher>()).Returns(mockPublisher.Object);
+
+        var result = await _testClass.Send(request, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        mockPublisher.Verify(p => p.Publish((INotification)notification, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Send_Should_Not_Publish_When_The_Handler_Completes_Asynchronously_With_No_CascadedNotifications()
+    {
+        var request = new TestCommand("Hello");
+
+        _mockHandler
+            .Setup(h => h.Handle(request, It.IsAny<CancellationToken>()))
+            .Returns(async () =>
+            {
+                await Task.Yield();
+                return Result.Success("OK");
+            });
+
+        var mockPublisher = new Mock<IPublisher>();
+        _mockHandlerResolver.Setup(r => r.Resolve<IPublisher>()).Returns(mockPublisher.Object);
+
+        var result = await _testClass.Send(request, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        mockPublisher.Verify(p => p.Publish(It.IsAny<INotification>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
     public async Task Send_Should_Not_Publish_CascadedNotifications_When_The_Result_Is_A_Failure()
     {
         var request = new TestCommand("Hello");

--- a/Tests/Mediarq.Tests/Core/Mediators/MediatorTests.cs
+++ b/Tests/Mediarq.Tests/Core/Mediators/MediatorTests.cs
@@ -198,4 +198,77 @@ public class MediatorTests
             r => r.ResolveAll<IPipelineBehavior<TestCommand, Result<string>>>(),
             Times.Exactly(2));
     }
+
+    public record TestNotification(string Text) : INotification;
+
+    [Fact]
+    public async Task Send_Should_Not_Resolve_IPublisher_When_Result_Has_No_CascadedNotifications()
+    {
+        var request = new TestCommand("Hello");
+        _mockHandler
+            .Setup(h => h.Handle(request, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success("OK"));
+
+        await _testClass.Send(request, CancellationToken.None);
+
+        // No cascaded notifications: the publisher is never even resolved, let alone invoked.
+        _mockHandlerResolver.Verify(r => r.Resolve<IPublisher>(), Times.Never);
+    }
+
+    [Fact]
+    public async Task Send_Should_Publish_CascadedNotifications_After_A_Successful_Result()
+    {
+        var request = new TestCommand("Hello");
+        var first = new TestNotification("first");
+        var second = new TestNotification("second");
+        _mockHandler
+            .Setup(h => h.Handle(request, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success("OK").WithNotifications(first, second));
+
+        var mockPublisher = new Mock<IPublisher>();
+        mockPublisher.Setup(p => p.Publish(It.IsAny<INotification>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        _mockHandlerResolver.Setup(r => r.Resolve<IPublisher>()).Returns(mockPublisher.Object);
+
+        var result = await _testClass.Send(request, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        // Cast to INotification: PipelineDispatch calls Publish<INotification>(...) (the static type of
+        // Result.CascadedNotifications' elements), not Publish<TestNotification>(...).
+        mockPublisher.Verify(p => p.Publish((INotification)first, It.IsAny<CancellationToken>()), Times.Once);
+        mockPublisher.Verify(p => p.Publish((INotification)second, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Send_Should_Not_Publish_CascadedNotifications_When_The_Result_Is_A_Failure()
+    {
+        var request = new TestCommand("Hello");
+        var notification = new TestNotification("never-published");
+        var error = ResultError.Failure("Boom", "boom");
+        _mockHandler
+            .Setup(h => h.Handle(request, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Failure<string>(error).WithNotifications(notification));
+
+        var mockPublisher = new Mock<IPublisher>();
+        _mockHandlerResolver.Setup(r => r.Resolve<IPublisher>()).Returns(mockPublisher.Object);
+
+        var result = await _testClass.Send(request, CancellationToken.None);
+
+        result.IsFailure.Should().BeTrue();
+        mockPublisher.Verify(p => p.Publish(It.IsAny<INotification>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Send_Should_Not_Throw_When_CascadedNotifications_Present_But_No_Publisher_Is_Registered()
+    {
+        var request = new TestCommand("Hello");
+        _mockHandler
+            .Setup(h => h.Handle(request, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success("OK").WithNotifications(new TestNotification("orphan")));
+
+        // No Resolve<IPublisher>() setup: Moq returns null, as a hand-built IHandlerResolver would if
+        // the core services were never registered.
+        var act = () => _testClass.Send(request, CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
+    }
 }

--- a/Tests/Mediarq.Tests/Data/IntegrationFixtures.cs
+++ b/Tests/Mediarq.Tests/Data/IntegrationFixtures.cs
@@ -115,6 +115,24 @@ public sealed class ThrowingCommandExceptionHandler : IRequestExceptionHandler<T
     }
 }
 
+// --- Command whose successful result cascades a notification to OrderPlaced's own handlers ---
+public record PlaceOrderCommand(int OrderId) : ICommand<Result<int>>;
+
+public sealed class PlaceOrderCommandHandler : ICommandHandler<PlaceOrderCommand, Result<int>>
+{
+    public Task<Result<int>> Handle(PlaceOrderCommand request, CancellationToken cancellationToken = default)
+        => Task.FromResult(Result.Success(request.OrderId).WithNotifications(new OrderPlaced(request.OrderId)));
+}
+
+// --- Command that attaches a cascaded notification but still fails: the notification must not publish ---
+public record FailingOrderCommand(int OrderId) : ICommand<Result<int>>;
+
+public sealed class FailingOrderCommandHandler : ICommandHandler<FailingOrderCommand, Result<int>>
+{
+    public Task<Result<int>> Handle(FailingOrderCommand request, CancellationToken cancellationToken = default)
+        => Task.FromResult(Result.Failure<int>(ResultError.Failure("Order.Failed", "boom")).WithNotifications(new OrderPlaced(request.OrderId)));
+}
+
 // --- Command surrounded by pre/post processors ---
 public record ProcessedCommand(string Name) : ICommand<Result<string>>;
 

--- a/Tests/Mediarq.Tests/Extensions/AddMediarqTests.cs
+++ b/Tests/Mediarq.Tests/Extensions/AddMediarqTests.cs
@@ -89,6 +89,37 @@ public class AddMediarqTests
     }
 
     [Fact]
+    public async Task Cascaded_Notifications_Are_Published_After_A_Successful_Result()
+    {
+        using var provider = BuildProvider();
+        using var scope = provider.CreateScope();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+        var trace = scope.ServiceProvider.GetRequiredService<ExecutionTrace>();
+
+        var result = await mediator.Send(new PlaceOrderCommand(42));
+
+        result.IsSuccess.Should().BeTrue();
+        // Reaches the very same OrderPlaced handlers a direct mediator.Publish(...) call would.
+        trace.Entries.Should().Contain("audit:42");
+        trace.Entries.Should().Contain("email:42");
+    }
+
+    [Fact]
+    public async Task Cascaded_Notifications_Are_Not_Published_When_The_Result_Is_A_Failure()
+    {
+        using var provider = BuildProvider();
+        using var scope = provider.CreateScope();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+        var trace = scope.ServiceProvider.GetRequiredService<ExecutionTrace>();
+
+        var result = await mediator.Send(new FailingOrderCommand(99));
+
+        result.IsFailure.Should().BeTrue();
+        trace.Entries.Should().NotContain("audit:99");
+        trace.Entries.Should().NotContain("email:99");
+    }
+
+    [Fact]
     public async Task ExceptionHandler_Converts_Thrown_Exception_To_Failed_Result()
     {
         using var provider = BuildProvider();

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -108,6 +108,7 @@ type is `Result`/`Result<T>` — the mediator doesn't look for cascaded notifica
 response shape (including `Unit`, a no-result `ICommand`'s response type).
 
 See [Wiring extensions](wiring-extensions.md#cascaded-notifications--resultwithnotifications).
+
 ## Routing
 
 ### Build warning `MQ202` — duplicate Mediarq route

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -97,6 +97,18 @@ This is a syntactic check, not a proof over every possible request type: it only
 is literally the `false` literal (an expression-bodied property, an expression-bodied getter, or a single
 `return false;`) — real conditional logic, however it evaluates at runtime, is never flagged.
 
+## Notifications
+
+### `Result.WithNotifications(...)` was called but the notification never publishes
+Cascaded notifications only publish **after a successful dispatch** — check `result.IsSuccess` on what
+your handler actually returned. A behavior/exception handler downstream that replaces the response with
+a different `Result` (e.g. converting a thrown exception into a failure) also short-circuits the
+cascade, since only the final response returned to the caller is inspected. Also confirm the response
+type is `Result`/`Result<T>` — the mediator doesn't look for cascaded notifications on any other
+response shape (including `Unit`, a no-result `ICommand`'s response type).
+
+See [Wiring extensions](wiring-extensions.md#cascaded-notifications--resultwithnotifications).
+
 ## Validation
 
 ### My validation never runs (no error, the handler just runs)

--- a/docs/guides/wiring-extensions.md
+++ b/docs/guides/wiring-extensions.md
@@ -31,6 +31,33 @@ Opt-in core behaviors (any order, after the call above):
 .AddMediarqTimeout()             // enforces ITimeoutRequest.Timeout -> RequestTimeoutException
 ```
 
+## Cascaded notifications — `Result.WithNotifications(...)`
+
+No registration needed. A handler can attach follow-up notifications to its own successful result
+instead of injecting `IPublisher` and calling `Publish(...)` itself:
+
+```csharp
+public sealed class CreateOrderHandler : ICommandHandler<CreateOrder, Result<Guid>>
+{
+    public Task<Result<Guid>> Handle(CreateOrder request, CancellationToken cancellationToken = default)
+    {
+        var id = Guid.NewGuid();
+        // ... persist the order ...
+        return Task.FromResult(Result.Success(id).WithNotifications(new OrderPlaced(id)));
+    }
+}
+```
+The mediator publishes `OrderPlaced` automatically once the request has finished dispatching — after
+every behavior, exception handler and post-processor has run — through the same `IPublisher` (and
+therefore the same registered `INotificationPublisher`: Parallel/Sequential/AggregateException) as an
+explicit `Publish(...)` call. **Only on a successful result**: a failed `Result`/`Result<T>` never
+publishes its attached notifications, even if `WithNotifications(...)` was called before the failure was
+known. Works with both `Result` and `Result<T>`; has no effect on other response shapes (e.g. `Unit`).
+
+Not automatically enqueued to `Mediarq.Outbox` — combine with an explicit `IOutbox.Enqueue(...)` call
+inside the handler if a cascaded notification needs the outbox's transactional/reliable delivery
+guarantee instead of an in-process publish.
+
 ## Validation
 
 ### Mediarq.FluentValidation

--- a/src/Mediarq.Core/Common/Pipeline/PipelineDispatch.cs
+++ b/src/Mediarq.Core/Common/Pipeline/PipelineDispatch.cs
@@ -1,6 +1,9 @@
 using Mediarq.Core.Common.Contexts;
 using Mediarq.Core.Common.Requests.Abstraction;
+using Mediarq.Core.Common.Requests.Notifications;
 using Mediarq.Core.Common.Resolvers;
+using Mediarq.Core.Common.Results;
+using Mediarq.Core.Mediators;
 
 namespace Mediarq.Core.Common.Pipeline;
 
@@ -123,7 +126,7 @@ internal static class PipelineDispatch
     {
         if (behaviorRegistrationCache?.IsKnownEmpty<TRequest, TResponse>() == true)
         {
-            return new ValueTask<TResponse>(handler.Handle(request, cancellationToken));
+            return WithCascadedNotifications(handler.Handle(request, cancellationToken), handlerResolver, cancellationToken);
         }
 
         var behaviors = handlerResolver.ResolveAll<IPipelineBehavior<TRequest, TResponse>>();
@@ -131,7 +134,7 @@ internal static class PipelineDispatch
         if (behaviors.Count == 0)
         {
             behaviorRegistrationCache?.MarkKnownEmpty<TRequest, TResponse>();
-            return new ValueTask<TResponse>(handler.Handle(request, cancellationToken));
+            return WithCascadedNotifications(handler.Handle(request, cancellationToken), handlerResolver, cancellationToken);
         }
 
         var active = SelectActive<TRequest, TResponse>(behaviors, out var activeCount);
@@ -140,12 +143,100 @@ internal static class PipelineDispatch
         // the handler directly — the hot path costs no more than a bare handler call.
         if (active is null)
         {
-            return new ValueTask<TResponse>(handler.Handle(request, cancellationToken));
+            return WithCascadedNotifications(handler.Handle(request, cancellationToken), handlerResolver, cancellationToken);
         }
 
         // A behavior will observe the context, so create it now (lazily, only when actually needed).
         RequestContext<TRequest, TResponse> context = requestContextFactory.Create<TRequest, TResponse>(request, cancellationToken);
-        return new ValueTask<TResponse>(Run(active, activeCount, context, () => handler.Handle(request, cancellationToken), cancellationToken));
+        return WithCascadedNotifications(
+            Run(active, activeCount, context, () => handler.Handle(request, cancellationToken), cancellationToken),
+            handlerResolver,
+            cancellationToken);
+    }
+
+    // Publishes notifications a handler attached to a successful Result/Result<T> via
+    // Result.WithNotifications(...), once the request has finished dispatching (after every behavior,
+    // exception handler and post-processor has run) — never on a failed result or a thrown exception.
+    // Gated on CascadeSupport<TResponse>.IsResultResponse (computed once per closed TResponse type) so
+    // a response type unrelated to Result pays nothing extra: the original task is returned as-is, same
+    // as before this feature existed. For a Result/Result<T> response that completed synchronously (the
+    // common case for the built-in benchmarks and most handlers), the check itself is synchronous too —
+    // the async continuation is only paid for when there is something to actually await or publish.
+    private static ValueTask<TResponse> WithCascadedNotifications<TResponse>(
+        Task<TResponse> responseTask, IHandlerResolver handlerResolver, CancellationToken cancellationToken)
+    {
+        if (!CascadeSupport<TResponse>.IsResultResponse)
+        {
+            return new ValueTask<TResponse>(responseTask);
+        }
+
+        if (responseTask.IsCompletedSuccessfully)
+        {
+            var response = responseTask.Result;
+            return HasCascadedNotifications(response, out var notifications)
+                ? new ValueTask<TResponse>(PublishThenReturnAsync(response, notifications, handlerResolver, cancellationToken))
+                : new ValueTask<TResponse>(responseTask);
+        }
+
+        return new ValueTask<TResponse>(AwaitThenPublishAsync(responseTask, handlerResolver, cancellationToken));
+    }
+
+    private static bool HasCascadedNotifications<TResponse>(TResponse response, out IReadOnlyList<INotification> notifications)
+    {
+        if (response is Result { IsSuccess: true } result && result.CascadedNotifications.Count > 0)
+        {
+            notifications = result.CascadedNotifications;
+            return true;
+        }
+
+        notifications = [];
+        return false;
+    }
+
+    private static async Task<TResponse> PublishThenReturnAsync<TResponse>(
+        TResponse response, IReadOnlyList<INotification> notifications, IHandlerResolver handlerResolver, CancellationToken cancellationToken)
+    {
+        await PublishAllAsync(notifications, handlerResolver, cancellationToken).ConfigureAwait(false);
+        return response;
+    }
+
+    private static async Task<TResponse> AwaitThenPublishAsync<TResponse>(
+        Task<TResponse> responseTask, IHandlerResolver handlerResolver, CancellationToken cancellationToken)
+    {
+        var response = await responseTask.ConfigureAwait(false);
+        if (HasCascadedNotifications(response, out var notifications))
+        {
+            await PublishAllAsync(notifications, handlerResolver, cancellationToken).ConfigureAwait(false);
+        }
+
+        return response;
+    }
+
+    // Cascaded notifications are published through the same resolved IPublisher (and therefore the same
+    // registered INotificationPublisher -- Parallel/Sequential/AggregateException) as an explicit
+    // IPublisher.Publish(...) call would use. Silently does nothing if IPublisher is not registered
+    // (e.g. a hand-built IHandlerResolver in a test that never registered the core services).
+    private static async Task PublishAllAsync(
+        IReadOnlyList<INotification> notifications, IHandlerResolver handlerResolver, CancellationToken cancellationToken)
+    {
+        var publisher = handlerResolver.Resolve<IPublisher>();
+        if (publisher is null)
+        {
+            return;
+        }
+
+        for (var i = 0; i < notifications.Count; i++)
+        {
+            await publisher.Publish(notifications[i], cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    // Cached once per closed TResponse type (the standard EqualityComparer<T>.Default-style pattern),
+    // so the "does this response type even support cascading" check costs nothing beyond the first call
+    // for a given TResponse -- most response types are not Result-derived and never pay for this feature.
+    private static class CascadeSupport<TResponse>
+    {
+        public static readonly bool IsResultResponse = typeof(Result).IsAssignableFrom(typeof(TResponse));
     }
 
     // Stable insertion sort by ascending Order (default int.MaxValue), copying into a fresh array so the

--- a/src/Mediarq.Core/Common/Results/Result.cs
+++ b/src/Mediarq.Core/Common/Results/Result.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
+using Mediarq.Core.Common.Requests.Notifications;
 
 namespace Mediarq.Core.Common.Results;
 
@@ -34,6 +35,38 @@ public class Result
     /// If the result represents success, this value is <see cref="ResultError.None"/>.
     /// </summary>
     public ResultError Error { get; init; }
+
+    private List<INotification>? _cascadedNotifications;
+
+    /// <summary>
+    /// Notifications attached via <see cref="WithNotifications"/>, to be published automatically by the
+    /// mediator after a successful dispatch. Empty unless <see cref="WithNotifications"/> was called.
+    /// </summary>
+    public IReadOnlyList<INotification> CascadedNotifications =>
+        (IReadOnlyList<INotification>?)_cascadedNotifications ?? Array.Empty<INotification>();
+
+    /// <summary>
+    /// Attaches one or more notifications to this result, for the mediator to publish automatically
+    /// once the request has been dispatched successfully — removing the need to inject
+    /// <see cref="Mediarq.Core.Mediators.IPublisher"/> and call <c>Publish(...)</c> explicitly from
+    /// within the handler. Has no effect on a failed result: cascaded notifications are only ever
+    /// published after a successful dispatch.
+    /// </summary>
+    /// <param name="notifications">The notifications to publish after a successful dispatch.</param>
+    /// <returns>This same result instance, for fluent chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="notifications"/> is <see langword="null"/>.</exception>
+    public virtual Result WithNotifications(params INotification[] notifications)
+    {
+        ArgumentNullException.ThrowIfNull(notifications);
+        if (notifications.Length == 0)
+        {
+            return this;
+        }
+
+        _cascadedNotifications ??= [];
+        _cascadedNotifications.AddRange(notifications);
+        return this;
+    }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Result"/> class.
@@ -167,4 +200,11 @@ public class Result<TValue> : Result
     /// A failed <see cref="Result{TValue}"/> representing a validation error.
     /// </returns>
     public static Result<TValue> ValidationFailure(ResultError error) => new(default, false, error);
+
+    /// <inheritdoc cref="Result.WithNotifications"/>
+    public override Result<TValue> WithNotifications(params INotification[] notifications)
+    {
+        base.WithNotifications(notifications);
+        return this;
+    }
 }

--- a/src/Mediarq.Core/PublicAPI.Unshipped.txt
+++ b/src/Mediarq.Core/PublicAPI.Unshipped.txt
@@ -3,5 +3,8 @@ Mediarq.Core.Common.Pipeline.PipelineBehaviorRegistrationCache
 Mediarq.Core.Common.Pipeline.PipelineBehaviorRegistrationCache.PipelineBehaviorRegistrationCache() -> void
 Mediarq.Core.Common.Requests.Notifications.IPolymorphicNotification
 Mediarq.Core.Common.Results.ErrorType.Forbidden = 6 -> Mediarq.Core.Common.Results.ErrorType
+Mediarq.Core.Common.Results.Result.CascadedNotifications.get -> System.Collections.Generic.IReadOnlyList<Mediarq.Core.Common.Requests.Notifications.INotification!>!
+override Mediarq.Core.Common.Results.Result<TValue>.WithNotifications(params Mediarq.Core.Common.Requests.Notifications.INotification![]! notifications) -> Mediarq.Core.Common.Results.Result<TValue>!
 static Mediarq.Core.Common.Results.ResultError.Forbidden(string! code, string! message) -> Mediarq.Core.Common.Results.ResultError!
 static Mediarq.Core.Common.Results.ResultError.Unauthorized(string! code, string! message) -> Mediarq.Core.Common.Results.ResultError!
+virtual Mediarq.Core.Common.Results.Result.WithNotifications(params Mediarq.Core.Common.Requests.Notifications.INotification![]! notifications) -> Mediarq.Core.Common.Results.Result!


### PR DESCRIPTION
## Summary
A handler that needs to raise a notification after completing its own work previously had to inject `IPublisher` and call `Publish(...)` itself, burying "what does this handler cause to happen next" in its body instead of its return type. This mirrors the differentiator called out in #216 (Wolverine-style cascading), scoped down per the design questions raised there:

- `Result.WithNotifications(...)` — virtual on `Result`, covariantly overridden on `Result<T>` to preserve the fluent return type — attaches notifications to a result. Mutates in place and returns `this`, so it composes naturally at the end of a handler's `return Task.FromResult(Result.Success(value).WithNotifications(...))`. Has no effect on serialization: `ResultJsonConverter` never touches the new field, so nothing leaks into HTTP responses, distributed cache entries, or idempotency replay payloads.
- `PipelineDispatch` publishes attached notifications through the resolved `IPublisher` — i.e. the same registered `INotificationPublisher` (Parallel/Sequential/AggregateException) an explicit `Publish(...)` call would use — once the request has fully finished dispatching (after every behavior, exception handler and post-processor has run), **and only when the final response is a successful `Result`/`Result<T>`**. A failed result, or an exception handler that replaces the response, never publishes attached notifications.
- Deliberately **not** wired to `Mediarq.Outbox`: a cascaded notification goes through `IPublisher.Publish(...)`, not `IOutbox.Enqueue(...)`. Combine both explicitly in the handler if a cascaded event needs the outbox's transactional/reliable-delivery guarantee.
- Performance: gated on `CascadeSupport<TResponse>.IsResultResponse`, computed once per closed `TResponse` type — any response type unrelated to `Result` (including `Unit`, most custom response types) pays nothing extra, same code path as before. For a `Result`/`Result<T>` response that completes synchronously with no attached notifications (the common case — e.g. `Task.FromResult(...)`), the check is also synchronous and the original task is returned unwrapped; the async continuation is only paid for when there's actually something to await or publish.

## Test plan
- [x] `dotnet test Tests/Mediarq.Tests` — 210/210 passing, including: `Result.WithNotifications` unit tests (fluent chaining preserves `Result<T>`, accumulates across calls, no-op on empty/null), `Mediator`-level mock tests (publishes on success, never on failure, never resolves `IPublisher` when there's nothing to cascade, doesn't throw when `IPublisher` isn't registered), and end-to-end DI tests through `AddMediarq` + a real notification handler (cascaded notification reaches the same handlers an explicit `Publish(...)` would, and is *not* delivered when the result fails).
- [x] `dotnet build Mediarq.sln -c Release` — 0 errors, 0 warnings beyond pre-existing Grpc protoc-generated ones.
- [x] `dotnet test Mediarq.sln -c Release --no-build` — full suite green (29/29 test projects).
- [x] Benchmark sanity check (`SendBenchmarks`, `--job short`, before/after via `git stash`): `Mediarq_Send`/`Mediarq_Send_Lean` (both `Result<string>`-returning, no cascading used) show a +8B delta (552B→560B / 248B→256B) — consistent with the JIT/tiering measurement noise floor already documented on this exact benchmark family in #210, not attributable to a real per-call allocation from this change's fast path.

Closes #216.