### PR TITLE
docs(samples): showcase Result.WithNotifications(...) cascading in the WebApi sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,8 +405,8 @@ Three runnable samples under [Samples/](Samples) (see [Samples/README.md](Sample
   pre/post processors, exception handling, timeout, `Result` combinators).
 - **[Mediarq.Samples.WebApi](Samples/Mediarq.Samples.WebApi)** — an ASP.NET Core "Orders" API wiring the
   extensions end-to-end (`Result` → HTTP, FluentValidation/DataAnnotations, caching, idempotency,
-  EF Core unit of work + transactional outbox + domain events, policy-based authorization, rate limiting,
-  health checks, Polly, diagnostics/OpenTelemetry, MassTransit).
+  EF Core unit of work + transactional outbox + domain events + cascaded notifications, policy-based
+  authorization, rate limiting, health checks, Polly, diagnostics/OpenTelemetry, MassTransit).
 - **[Mediarq.AotSample](Samples/Mediarq.AotSample)** — the reflection-free path, published with Native AOT.
 
 ```bash

--- a/Samples/Mediarq.Samples.WebApi/Features/Orders/AddOrderNote.cs
+++ b/Samples/Mediarq.Samples.WebApi/Features/Orders/AddOrderNote.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using Mediarq.Core.Common.Requests.Command;
+using Mediarq.Core.Common.Requests.Notifications;
 using Mediarq.Core.Common.Results;
 using Mediarq.Samples.WebApi.Domain;
 using Microsoft.EntityFrameworkCore;
@@ -31,6 +32,25 @@ public sealed class AddOrderNoteHandler(AppDbContext db)
 
         order.Note = request.Note;
         await db.SaveChangesAsync(cancellationToken);
-        return Result.Success();
+
+        // Cascaded notification: attached to the successful Result instead of injecting IPublisher and
+        // calling Publish(...) explicitly. Published automatically after dispatch, and only on success —
+        // a lightweight, in-process alternative to the transactional outbox (CreateOrder) and domain
+        // events (ConfirmOrder) used elsewhere in this sample.
+        return Result.Success().WithNotifications(new OrderNoteAddedEvent(order.Id, request.Note));
+    }
+}
+
+/// <summary>Cascaded via <see cref="Result.WithNotifications"/> — no explicit <c>IPublisher</c> injection needed.</summary>
+public sealed record OrderNoteAddedEvent(Guid OrderId, string Note) : INotification;
+
+public sealed class LogOrderNoteAddedHandler(ILogger<LogOrderNoteAddedHandler> logger)
+    : INotificationHandler<OrderNoteAddedEvent>
+{
+    public Task Handle(OrderNoteAddedEvent notification, CancellationToken cancellationToken = default)
+    {
+        logger.LogInformation("[cascaded notification] note added to order {OrderId}: {Note}",
+            notification.OrderId, notification.Note);
+        return Task.CompletedTask;
     }
 }

--- a/Samples/README.md
+++ b/Samples/README.md
@@ -25,7 +25,7 @@ at `/scalar/v1` to exercise the endpoints:
 | `POST /orders` | Create — FluentValidation, unit of work commit, **transactional outbox** event, **rate-limited** (5/min, see the "create-order" policy) |
 | `GET /orders/{id}` | Read — memoized by the **caching** behavior (second identical call skips the DB) |
 | `POST /orders/{id}/confirm` | **Idempotent** (send the same `Idempotency-Key` header to replay) and **authorized** — requires `X-User` + `X-Role: manager` headers (see below), raises a **domain event** on success |
-| `POST /orders/{id}/note` | **DataAnnotations** validation (an empty note returns a 400 ProblemDetails) |
+| `POST /orders/{id}/note` | **DataAnnotations** validation (an empty note returns a 400 ProblemDetails), publishes a **cascaded notification** (`Result.WithNotifications(...)`) |
 | `GET /orders/{id}/quote` | **Polly** resilience — retries a flaky pricing service |
 | `GET /orders/stream` | **Streaming** — `IAsyncEnumerable` of orders |
 | `GET /health` | **Health check** — reports unhealthy if a command/query doesn't resolve to exactly one handler |
@@ -33,7 +33,10 @@ at `/scalar/v1` to exercise the endpoints:
 Watch the console: the outbox publishes `OrderPlacedEvent` to its in-process handlers **and** forwards it
 onto the in-memory MassTransit bus; confirming an order raises an in-process `OrderConfirmedDomainEvent`
 via `Mediarq.EntityFrameworkCore`'s `AggregateRoot`/`DomainEventsInterceptor` instead (published right
-after `SaveChanges` commits, no outbox/bus hop); and OpenTelemetry exports Mediarq activities/metrics.
+after `SaveChanges` commits, no outbox/bus hop); adding a note cascades `OrderNoteAddedEvent` straight
+from the handler's return value (`Result.WithNotifications(...)`, no `IPublisher` injected, no outbox
+involved — the lightest-weight of the three notification patterns this sample shows side by side); and
+OpenTelemetry exports Mediarq activities/metrics.
 
 Authorization uses a deliberately trivial header-based "authentication" scheme for this sample only (see
 `Security/DemoHeaderAuthentication.cs`) — never do this outside a demo:


### PR DESCRIPTION
## Summary
- `AddOrderNoteHandler` (WebApi sample) now attaches an `OrderNoteAddedEvent` to its successful `Result` via `Result.WithNotifications(...)` instead of just returning it — no `IPublisher` injected, no outbox involved.
- Gives the sample a third notification pattern shown side by side with the two it already had: the transactional outbox (`CreateOrder` → `OrderPlacedEvent`) and domain events (`ConfirmOrder` → `OrderConfirmedDomainEvent`), so a reader can compare all three at a glance.
- Updated `Samples/README.md` (endpoint table + "watch the console" paragraph) and the root `README.md`'s sample blurb to mention it.

## Test plan
- [x] `dotnet build Mediarq.sln -c Release` — 0 errors, 0 warnings.
- [x] `dotnet test Mediarq.sln -c Release --no-build` — full suite green (29/29 test projects, unaffected by this change).
- [x] Ran the sample locally: created an order, `POST /orders/{id}/note`, confirmed the `[cascaded notification] note added to order ...` log line fires from the new `INotificationHandler`.